### PR TITLE
d/patches: add patch to fix migration problem

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qemu (1:2.11+dfsg-1ubuntu7.3+bionic0+exo2) bionic; urgency=medium
+
+  * d/patches: add patch to fix migration
+    https://bugs.launchpad.net/qemu/+bug/1775555
+
+  -- Jean-Philippe Menil <jpmenil@exoscale.ch>  Tue, 21 Aug 2018 10:00:00 +0200
+
 qemu (1:2.11+dfsg-1ubuntu7.3+bionic0+exo1) bionic; urgency=medium
 
   * Update for bionic.

--- a/debian/patches/fix-clock_is_reliable-on-migration.patch
+++ b/debian/patches/fix-clock_is_reliable-on-migration.patch
@@ -46,3 +46,5 @@ kvmclock_reliable_get_clock = {
      .pre_save = kvmclock_pre_save,
      .fields = (VMStateField[]) {
          VMSTATE_UINT64(clock, KVMClockState),
+-- 
+1.8.3.1

--- a/debian/patches/fix-clock_is_reliable-on-migration.patch
+++ b/debian/patches/fix-clock_is_reliable-on-migration.patch
@@ -1,0 +1,48 @@
+From: Michael Chapman <address@hidden>
+
+When migrating from a pre-2.9 QEMU, no clock_is_reliable flag is
+transferred. We should assume that the source host has an unreliable
+KVM_GET_CLOCK, rather than using whatever was determined locally, to
+ensure that any drift from the TSC-based value calculated by the guest
+is corrected.
+
+Signed-off-by: Michael Chapman <address@hidden>
+Message-Id: <address@hidden>
+Signed-off-by: Paolo Bonzini <address@hidden>
+---
+ hw/i386/kvm/clock.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/hw/i386/kvm/clock.c b/hw/i386/kvm/clock.c
+index 1707434..7dac319 100644
+--- a/hw/i386/kvm/clock.c
++++ b/hw/i386/kvm/clock.c
+@@ -242,6 +242,19 @@ static const VMStateDescription 
+kvmclock_reliable_get_clock = {
+ };
+ 
+ /*
++ * When migrating, assume the source has an unreliable
++ * KVM_GET_CLOCK unless told otherwise.
++ */
++static int kvmclock_pre_load(void *opaque)
++{
++    KVMClockState *s = opaque;
++
++    s->clock_is_reliable = false;
++
++    return 0;
++}
++
++/*
+  * When migrating, read the clock just before migration,
+  * so that the guest clock counts during the events
+  * between:
+@@ -268,6 +281,7 @@ static const VMStateDescription kvmclock_vmsd = {
+     .name = "kvmclock",
+     .version_id = 1,
+     .minimum_version_id = 1,
++    .pre_load = kvmclock_pre_load,
+     .pre_save = kvmclock_pre_save,
+     .fields = (VMStateField[]) {
+         VMSTATE_UINT64(clock, KVMClockState),

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
+fix-clock_is_reliable-on-migration.patch
 use-fixed-data-path.patch
 use-data-path.patch
 


### PR DESCRIPTION
During migration, some vms are stuck, even if the state is running.
See https://bugs.launchpad.net/qemu/+bug/1775555 for more details.