### PR TITLE
Import 1:4.2-3ubuntu6.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+qemu (1:4.2-3ubuntu6.8+exo2) UNRELEASED; urgency=medium
+
+  * Import 1:4.2-3ubuntu6.8
+  * Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Tue, 17 Nov 2020 16:28:32 +0000
+
+qemu (1:4.2-3ubuntu6.8) focal; urgency=medium
+
+  * d/p/u/lp-1894942-*: fix virtio-ccw host/guest notification (LP: #1894942)
+
+ -- Christian Ehrhardt <christian.ehrhardt@canonical.com>  Mon, 21 Sep 2020 15:35:30 +0200
+
 qemu (1:4.2-3ubuntu6.7+exo2) UNRELEASED; urgency=medium
 
   * Import 1:4.2-3ubuntu6.7

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -229,6 +229,8 @@ ubuntu/lp-1882774-i386-Add-missing-cpu-feature-bits-in-EPYC-model.patch
 ubuntu/lp-1882774-i386-Add-2nd-Generation-AMD-EPYC-processors.patch
 ubuntu/lp-1896751-exec-rom_reset-Free-rom-data-during-inmigrate-skip.patch
 ubuntu/lp-1849644-io-channel-websock-treat-binary-and-no-sub-protocol-.patch
+ubuntu/lp-1894942-virtio-ccw-fix-virtio_set_ind_atomic.patch
+ubuntu/lp-1894942-s390x-pci-fix-set_ind_atomic.patch
 
 # Exoscale
 exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch

--- a/debian/patches/ubuntu/lp-1894942-s390x-pci-fix-set_ind_atomic.patch
+++ b/debian/patches/ubuntu/lp-1894942-s390x-pci-fix-set_ind_atomic.patch
@@ -1,0 +1,67 @@
+From 45175361f1bfc2d3ccdcb4b22570c2352f3de754 Mon Sep 17 00:00:00 2001
+From: Halil Pasic <pasic@linux.ibm.com>
+Date: Tue, 16 Jun 2020 06:50:35 +0200
+Subject: [PATCH] s390x/pci: fix set_ind_atomic
+
+The atomic_cmpxchg() loop is broken because we occasionally end up with
+old and _old having different values (a legit compiler can generate code
+that accessed *ind_addr again to pick up a value for _old instead of
+using the value of old that was already fetched according to the
+rules of the abstract machine). This means the underlying CS instruction
+may use a different old (_old) than the one we intended to use if
+atomic_cmpxchg() performed the xchg part.
+
+Let us use volatile to force the rules of the abstract machine for
+accesses to *ind_addr. Let us also rewrite the loop so, we that the
+new old is used to compute the new desired value if the xchg part
+is not performed.
+
+Fixes: 8cba80c3a0 ("s390: Add PCI bus support")
+Reported-by: Christian Borntraeger <borntraeger@de.ibm.com>
+Signed-off-by: Halil Pasic <pasic@linux.ibm.com>
+Reviewed-by: Christian Borntraeger <borntraeger@de.ibm.com>
+Message-Id: <20200616045035.51641-3-pasic@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+Origin: backport, https://git.qemu.org/?p=qemu.git;a=commit;h=45175361f1
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1894942
+Last-Update: 2020-09-21
+
+---
+ hw/s390x/s390-pci-bus.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+--- a/hw/s390x/s390-pci-bus.c
++++ b/hw/s390x/s390-pci-bus.c
+@@ -637,22 +637,24 @@ static AddressSpace *s390_pci_dma_iommu(
+ 
+ static uint8_t set_ind_atomic(uint64_t ind_loc, uint8_t to_be_set)
+ {
+-    uint8_t ind_old, ind_new;
++    uint8_t expected, actual;
+     hwaddr len = 1;
+-    uint8_t *ind_addr;
++    /* avoid  multiple fetches */
++    uint8_t volatile *ind_addr;
+ 
+     ind_addr = cpu_physical_memory_map(ind_loc, &len, 1);
+     if (!ind_addr) {
+         s390_pci_generate_error_event(ERR_EVENT_AIRERR, 0, 0, 0, 0);
+         return -1;
+     }
++    actual = *ind_addr;
+     do {
+-        ind_old = *ind_addr;
+-        ind_new = ind_old | to_be_set;
+-    } while (atomic_cmpxchg(ind_addr, ind_old, ind_new) != ind_old);
+-    cpu_physical_memory_unmap(ind_addr, len, 1, len);
++        expected = actual;
++        actual = atomic_cmpxchg(ind_addr, expected, expected | to_be_set);
++    } while (actual != expected);
++    cpu_physical_memory_unmap((void *)ind_addr, len, 1, len);
+ 
+-    return ind_old;
++    return actual;
+ }
+ 
+ static void s390_msi_ctrl_write(void *opaque, hwaddr addr, uint64_t data,

--- a/debian/patches/ubuntu/lp-1894942-virtio-ccw-fix-virtio_set_ind_atomic.patch
+++ b/debian/patches/ubuntu/lp-1894942-virtio-ccw-fix-virtio_set_ind_atomic.patch
@@ -1,0 +1,70 @@
+From 1a8242f7c3f53341dd66253b142ecd06ce1d2a97 Mon Sep 17 00:00:00 2001
+From: Halil Pasic <pasic@linux.ibm.com>
+Date: Tue, 16 Jun 2020 06:50:34 +0200
+Subject: [PATCH] virtio-ccw: fix virtio_set_ind_atomic
+
+The atomic_cmpxchg() loop is broken because we occasionally end up with
+old and _old having different values (a legit compiler can generate code
+that accessed *ind_addr again to pick up a value for _old instead of
+using the value of old that was already fetched according to the
+rules of the abstract machine). This means the underlying CS instruction
+may use a different old (_old) than the one we intended to use if
+atomic_cmpxchg() performed the xchg part.
+
+Let us use volatile to force the rules of the abstract machine for
+accesses to *ind_addr. Let us also rewrite the loop so, we that the
+new old is used to compute the new desired value if the xchg part
+is not performed.
+
+Fixes: 7e7494627f ("s390x/virtio-ccw: Adapter interrupt support.")
+Reported-by: Andre Wild <Andre.Wild1@ibm.com>
+Signed-off-by: Halil Pasic <pasic@linux.ibm.com>
+Reviewed-by: Christian Borntraeger <borntraeger@de.ibm.com>
+Message-Id: <20200616045035.51641-2-pasic@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+Origin: backport, https://git.qemu.org/?p=qemu.git;a=commit;h=1a8242f7c3
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1894942
+Last-Update: 2020-09-21
+
+---
+ hw/s390x/virtio-ccw.c | 18 ++++++++++--------
+ 1 file changed, 10 insertions(+), 8 deletions(-)
+
+--- a/hw/s390x/virtio-ccw.c
++++ b/hw/s390x/virtio-ccw.c
+@@ -786,9 +786,10 @@ static inline VirtioCcwDevice *to_virtio
+ static uint8_t virtio_set_ind_atomic(SubchDev *sch, uint64_t ind_loc,
+                                      uint8_t to_be_set)
+ {
+-    uint8_t ind_old, ind_new;
++    uint8_t expected, actual;
+     hwaddr len = 1;
+-    uint8_t *ind_addr;
++    /* avoid  multiple fetches */
++    uint8_t volatile *ind_addr;
+ 
+     ind_addr = cpu_physical_memory_map(ind_loc, &len, 1);
+     if (!ind_addr) {
+@@ -796,14 +797,15 @@ static uint8_t virtio_set_ind_atomic(Sub
+                      __func__, sch->cssid, sch->ssid, sch->schid);
+         return -1;
+     }
++    actual = *ind_addr;
+     do {
+-        ind_old = *ind_addr;
+-        ind_new = ind_old | to_be_set;
+-    } while (atomic_cmpxchg(ind_addr, ind_old, ind_new) != ind_old);
+-    trace_virtio_ccw_set_ind(ind_loc, ind_old, ind_new);
+-    cpu_physical_memory_unmap(ind_addr, len, 1, len);
++        expected = actual;
++        actual = atomic_cmpxchg(ind_addr, expected, expected | to_be_set);
++    } while (actual != expected);
++    trace_virtio_ccw_set_ind(ind_loc, actual, actual | to_be_set);
++    cpu_physical_memory_unmap((void *)ind_addr, len, 1, len);
+ 
+-    return ind_old;
++    return actual;
+ }
+ 
+ static void virtio_ccw_notify(DeviceState *d, uint16_t vector)


### PR DESCRIPTION
This patch is needed to keep this package in sync with Ubuntu's

 - Import 1:4.2-3ubuntu6.8
 - Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
