### PR TITLE
Import 1:4.2-3ubuntu6.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,51 @@
+qemu (1:4.2-3ubuntu6.10+exo2) UNRELEASED; urgency=medium
+
+  * Import 1:4.2-3ubuntu6.10
+  * Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Mon, 04 Jan 2021 10:58:39 +0000
+
+qemu (1:4.2-3ubuntu6.10) focal-security; urgency=medium
+
+  * SECURITY UPDATE: heap buffer overflow in sdhci_sdma_transfer_multi_blocks()
+    - debian/patches/ubuntu/CVE-2020-17380.patch: fix DMA Transfer Block
+      Size field in hw/sd/sdhci.c.
+    - CVE-2020-17380
+    - CVE-2020-25085
+  * SECURITY UPDATE: use-after-free via unchecked return value
+    - debian/patches/ubuntu/CVE-2020-25084.patch: check return value of
+      'usb_packet_map' in hw/usb/hcd-xhci.c.
+    - CVE-2020-25084
+  * SECURITY UPDATE: out-of-bound access issue
+    - debian/patches/ubuntu/CVE-2020-25624.patch: check len and
+      frame_number variables in hw/usb/hcd-ohci.c.
+    - CVE-2020-25624
+  * SECURITY UPDATE: infinite loop when a TD list has a loop
+    - debian/patches/ubuntu/CVE-2020-25625.patch: check for processed TD
+      before retire in hw/usb/hcd-ohci.c.
+    - CVE-2020-25625
+  * SECURITY UPDATE: assertion failure through usb_packet_unmap()
+    - debian/patches/ubuntu/CVE-2020-25723.patch: check return value of
+      'usb_packet_map' in hw/usb/hcd-ehci.c.
+    - CVE-2020-25723
+  * SECURITY UPDATE: bounds issue in ati_2d_blt
+    - debian/patches/ubuntu/CVE-2020-27616.patch: check x y display
+      parameter values in hw/display/ati_2d.c.
+    - CVE-2020-27616
+  * SECURITY UPDATE: assertion failure
+    - debian/patches/ubuntu/CVE-2020-27617.patch: remove an assert call in
+      eth_get_gso_type in net/eth.c.
+    - CVE-2020-27617
+
+ -- Marc Deslauriers <marc.deslauriers@ubuntu.com>  Fri, 20 Nov 2020 08:12:00 -0500
+
+qemu (1:4.2-3ubuntu6.9) focal; urgency=medium
+
+  * d/p/ubuntu/define-ubuntu-machine-types.patch: update to fix 15.04 wily
+    machine type to match how it originally was released (LP: #1902654)
+
+ -- Christian Ehrhardt <christian.ehrhardt@canonical.com>  Wed, 04 Nov 2020 15:34:47 +0100
+
 qemu (1:4.2-3ubuntu6.8+exo2) UNRELEASED; urgency=medium
 
   * Import 1:4.2-3ubuntu6.8

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -231,6 +231,13 @@ ubuntu/lp-1896751-exec-rom_reset-Free-rom-data-during-inmigrate-skip.patch
 ubuntu/lp-1849644-io-channel-websock-treat-binary-and-no-sub-protocol-.patch
 ubuntu/lp-1894942-virtio-ccw-fix-virtio_set_ind_atomic.patch
 ubuntu/lp-1894942-s390x-pci-fix-set_ind_atomic.patch
+ubuntu/CVE-2020-17380.patch
+ubuntu/CVE-2020-25084.patch
+ubuntu/CVE-2020-25624.patch
+ubuntu/CVE-2020-25625.patch
+ubuntu/CVE-2020-25723.patch
+ubuntu/CVE-2020-27616.patch
+ubuntu/CVE-2020-27617.patch
 
 # Exoscale
 exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch

--- a/debian/patches/ubuntu/CVE-2020-17380.patch
+++ b/debian/patches/ubuntu/CVE-2020-17380.patch
@@ -1,0 +1,39 @@
+From dfba99f17feb6d4a129da19d38df1bcd8579d1c3 Mon Sep 17 00:00:00 2001
+From: =?utf8?q?Philippe=20Mathieu-Daud=C3=A9?= <f4bug@amsat.org>
+Date: Tue, 1 Sep 2020 15:22:06 +0200
+Subject: [PATCH] hw/sd/sdhci: Fix DMA Transfer Block Size field
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf8
+Content-Transfer-Encoding: 8bit
+
+The 'Transfer Block Size' field is 12-bit wide.
+
+See section '2.2.2. Block Size Register (Offset 004h)' in datasheet.
+
+Two different bug reproducer available:
+- https://bugs.launchpad.net/qemu/+bug/1892960
+- https://ruhr-uni-bochum.sciebo.de/s/NNWP2GfwzYKeKwE?path=%2Fsdhci_oob_write1
+
+Cc: qemu-stable@nongnu.org
+Buglink: https://bugs.launchpad.net/qemu/+bug/1892960
+Fixes: d7dfca0807a ("hw/sdhci: introduce standard SD host controller")
+Reported-by: Alexander Bulekov <alxndr@bu.edu>
+Signed-off-by: Philippe Mathieu-DaudÃ© <f4bug@amsat.org>
+Reviewed-by: Prasad J Pandit <pjp@fedoraproject.org>
+Tested-by: Alexander Bulekov <alxndr@bu.edu>
+Message-Id: <20200901140411.112150-3-f4bug@amsat.org>
+---
+ hw/sd/sdhci.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/hw/sd/sdhci.c
++++ b/hw/sd/sdhci.c
+@@ -1129,7 +1129,7 @@ sdhci_write(void *opaque, hwaddr offset,
+         break;
+     case SDHC_BLKSIZE:
+         if (!TRANSFERRING_DATA(s->prnsts)) {
+-            MASKED_WRITE(s->blksize, mask, value);
++            MASKED_WRITE(s->blksize, mask, extract32(value, 0, 12));
+             MASKED_WRITE(s->blkcnt, mask >> 16, value >> 16);
+         }
+ 

--- a/debian/patches/ubuntu/CVE-2020-25084.patch
+++ b/debian/patches/ubuntu/CVE-2020-25084.patch
@@ -1,0 +1,74 @@
+From 21bc31524e8ca487e976f713b878d7338ee00df2 Mon Sep 17 00:00:00 2001
+From: Li Qiang <liq3ea@163.com>
+Date: Wed, 12 Aug 2020 08:31:39 -0700
+Subject: [PATCH] hw: xhci: check return value of 'usb_packet_map'
+
+Currently we don't check the return value of 'usb_packet_map',
+this will cause an UAF issue. This is LP#1891341.
+Following is the reproducer provided in:
+-->https://bugs.launchpad.net/qemu/+bug/1891341
+
+cat << EOF | ./i386-softmmu/qemu-system-i386 -device nec-usb-xhci \
+-trace usb\* -device usb-audio -device usb-storage,drive=mydrive \
+-drive id=mydrive,file=null-co://,size=2M,format=raw,if=none \
+-nodefaults -nographic -qtest stdio
+outl 0xcf8 0x80001016
+outl 0xcfc 0x3c009f0d
+outl 0xcf8 0x80001004
+outl 0xcfc 0xc77695e
+writel 0x9f0d000000000040 0xffff3655
+writeq 0x9f0d000000002000 0xff2f9e0000000000
+write 0x1d 0x1 0x27
+write 0x2d 0x1 0x2e
+write 0x17232 0x1 0x03
+write 0x17254 0x1 0x06
+write 0x17278 0x1 0x34
+write 0x3d 0x1 0x27
+write 0x40 0x1 0x2e
+write 0x41 0x1 0x72
+write 0x42 0x1 0x01
+write 0x4d 0x1 0x2e
+write 0x4f 0x1 0x01
+writeq 0x9f0d000000002000 0x5c051a0100000000
+write 0x34001d 0x1 0x13
+write 0x340026 0x1 0x30
+write 0x340028 0x1 0x08
+write 0x34002c 0x1 0xfe
+write 0x34002d 0x1 0x08
+write 0x340037 0x1 0x5e
+write 0x34003a 0x1 0x05
+write 0x34003d 0x1 0x05
+write 0x34004d 0x1 0x13
+writeq 0x9f0d000000002000 0xff00010100400009
+EOF
+
+This patch fixes this.
+
+Buglink: https://bugs.launchpad.net/qemu/+bug/1891341
+Reported-by: Alexander Bulekov <alxndr@bu.edu>
+Signed-off-by: Li Qiang <liq3ea@163.com>
+Message-id: 20200812153139.15146-1-liq3ea@163.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+---
+ hw/usb/hcd-xhci.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/hw/usb/hcd-xhci.c b/hw/usb/hcd-xhci.c
+index 67a18fe..46a2186 100644
+--- a/hw/usb/hcd-xhci.c
++++ b/hw/usb/hcd-xhci.c
+@@ -1615,7 +1615,10 @@ static int xhci_setup_packet(XHCITransfer *xfer)
+     xhci_xfer_create_sgl(xfer, dir == USB_TOKEN_IN); /* Also sets int_req */
+     usb_packet_setup(&xfer->packet, dir, ep, xfer->streamid,
+                      xfer->trbs[0].addr, false, xfer->int_req);
+-    usb_packet_map(&xfer->packet, &xfer->sgl);
++    if (usb_packet_map(&xfer->packet, &xfer->sgl)) {
++        qemu_sglist_destroy(&xfer->sgl);
++        return -1;
++    }
+     DPRINTF("xhci: setup packet pid 0x%x addr %d ep %d\n",
+             xfer->packet.pid, ep->dev->addr, ep->nr);
+     return 0;
+-- 
+1.8.3.1
+

--- a/debian/patches/ubuntu/CVE-2020-25624.patch
+++ b/debian/patches/ubuntu/CVE-2020-25624.patch
@@ -1,0 +1,96 @@
+From 1328fe0c32d5474604105b8105310e944976b058 Mon Sep 17 00:00:00 2001
+From: Prasad J Pandit <pjp@fedoraproject.org>
+Date: Tue, 15 Sep 2020 23:52:58 +0530
+Subject: [PATCH] hw: usb: hcd-ohci: check len and frame_number variables
+
+While servicing the OHCI transfer descriptors(TD), OHCI host
+controller derives variables 'start_addr', 'end_addr', 'len'
+etc. from values supplied by the host controller driver.
+Host controller driver may supply values such that using
+above variables leads to out-of-bounds access issues.
+Add checks to avoid them.
+
+AddressSanitizer: stack-buffer-overflow on address 0x7ffd53af76a0
+  READ of size 2 at 0x7ffd53af76a0 thread T0
+  #0 ohci_service_iso_td ../hw/usb/hcd-ohci.c:734
+  #1 ohci_service_ed_list ../hw/usb/hcd-ohci.c:1180
+  #2 ohci_process_lists ../hw/usb/hcd-ohci.c:1214
+  #3 ohci_frame_boundary ../hw/usb/hcd-ohci.c:1257
+  #4 timerlist_run_timers ../util/qemu-timer.c:572
+  #5 qemu_clock_run_timers ../util/qemu-timer.c:586
+  #6 qemu_clock_run_all_timers ../util/qemu-timer.c:672
+  #7 main_loop_wait ../util/main-loop.c:527
+  #8 qemu_main_loop ../softmmu/vl.c:1676
+  #9 main ../softmmu/main.c:50
+
+Reported-by: Gaoning Pan <pgn@zju.edu.cn>
+Reported-by: Yongkang Jia <j_kangel@163.com>
+Reported-by: Yi Ren <yunye.ry@alibaba-inc.com>
+Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
+Message-id: 20200915182259.68522-2-ppandit@redhat.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+---
+ hw/usb/hcd-ohci.c | 24 ++++++++++++++++++++++--
+ 1 file changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/hw/usb/hcd-ohci.c b/hw/usb/hcd-ohci.c
+index 1e6e85e..9dc5910 100644
+--- a/hw/usb/hcd-ohci.c
++++ b/hw/usb/hcd-ohci.c
+@@ -731,7 +731,11 @@ static int ohci_service_iso_td(OHCIState *ohci, struct ohci_ed *ed,
+     }
+ 
+     start_offset = iso_td.offset[relative_frame_number];
+-    next_offset = iso_td.offset[relative_frame_number + 1];
++    if (relative_frame_number < frame_count) {
++        next_offset = iso_td.offset[relative_frame_number + 1];
++    } else {
++        next_offset = iso_td.be;
++    }
+ 
+     if (!(OHCI_BM(start_offset, TD_PSW_CC) & 0xe) || 
+         ((relative_frame_number < frame_count) && 
+@@ -764,7 +768,12 @@ static int ohci_service_iso_td(OHCIState *ohci, struct ohci_ed *ed,
+         }
+     } else {
+         /* Last packet in the ISO TD */
+-        end_addr = iso_td.be;
++        end_addr = next_offset;
++    }
++
++    if (start_addr > end_addr) {
++        trace_usb_ohci_iso_td_bad_cc_overrun(start_addr, end_addr);
++        return 1;
+     }
+ 
+     if ((start_addr & OHCI_PAGE_MASK) != (end_addr & OHCI_PAGE_MASK)) {
+@@ -773,6 +782,9 @@ static int ohci_service_iso_td(OHCIState *ohci, struct ohci_ed *ed,
+     } else {
+         len = end_addr - start_addr + 1;
+     }
++    if (len > sizeof(ohci->usb_buf)) {
++        len = sizeof(ohci->usb_buf);
++    }
+ 
+     if (len && dir != OHCI_TD_DIR_IN) {
+         if (ohci_copy_iso_td(ohci, start_addr, end_addr, ohci->usb_buf, len,
+@@ -975,8 +987,16 @@ static int ohci_service_td(OHCIState *ohci, struct ohci_ed *ed)
+         if ((td.cbp & 0xfffff000) != (td.be & 0xfffff000)) {
+             len = (td.be & 0xfff) + 0x1001 - (td.cbp & 0xfff);
+         } else {
++            if (td.cbp > td.be) {
++                trace_usb_ohci_iso_td_bad_cc_overrun(td.cbp, td.be);
++                ohci_die(ohci);
++                return 1;
++            }
+             len = (td.be - td.cbp) + 1;
+         }
++        if (len > sizeof(ohci->usb_buf)) {
++            len = sizeof(ohci->usb_buf);
++        }
+ 
+         pktlen = len;
+         if (len && dir != OHCI_TD_DIR_IN) {
+-- 
+1.8.3.1
+

--- a/debian/patches/ubuntu/CVE-2020-25625.patch
+++ b/debian/patches/ubuntu/CVE-2020-25625.patch
@@ -1,0 +1,37 @@
+From 1be90ebecc95b09a2ee5af3f60c412b45a766c4f Mon Sep 17 00:00:00 2001
+From: Prasad J Pandit <pjp@fedoraproject.org>
+Date: Tue, 15 Sep 2020 23:52:59 +0530
+Subject: [PATCH] hw: usb: hcd-ohci: check for processed TD before retire
+
+While servicing OHCI transfer descriptors(TD), ohci_service_iso_td
+retires a TD if it has passed its time frame. It does not check if
+the TD was already processed once and holds an error code in TD_CC.
+It may happen if the TD list has a loop. Add check to avoid an
+infinite loop condition.
+
+Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
+Reviewed-by: Li Qiang <liq3ea@gmail.com>
+Message-id: 20200915182259.68522-3-ppandit@redhat.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+---
+ hw/usb/hcd-ohci.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/hw/usb/hcd-ohci.c b/hw/usb/hcd-ohci.c
+index 9dc5910..8b912e9 100644
+--- a/hw/usb/hcd-ohci.c
++++ b/hw/usb/hcd-ohci.c
+@@ -691,6 +691,10 @@ static int ohci_service_iso_td(OHCIState *ohci, struct ohci_ed *ed,
+            the next ISO TD of the same ED */
+         trace_usb_ohci_iso_td_relative_frame_number_big(relative_frame_number,
+                                                         frame_count);
++        if (OHCI_CC_DATAOVERRUN == OHCI_BM(iso_td.flags, TD_CC)) {
++            /* avoid infinite loop */
++            return 1;
++        }
+         OHCI_SET_BM(iso_td.flags, TD_CC, OHCI_CC_DATAOVERRUN);
+         ed->head &= ~OHCI_DPTR_MASK;
+         ed->head |= (iso_td.next & OHCI_DPTR_MASK);
+-- 
+1.8.3.1
+

--- a/debian/patches/ubuntu/CVE-2020-25723.patch
+++ b/debian/patches/ubuntu/CVE-2020-25723.patch
@@ -1,0 +1,41 @@
+From 2fdb42d840400d58f2e706ecca82c142b97bcbd6 Mon Sep 17 00:00:00 2001
+From: Li Qiang <liq3ea@163.com>
+Date: Wed, 12 Aug 2020 09:17:27 -0700
+Subject: [PATCH] hw: ehci: check return value of 'usb_packet_map'
+
+If 'usb_packet_map' fails, we should stop to process the usb
+request.
+
+Signed-off-by: Li Qiang <liq3ea@163.com>
+Message-Id: <20200812161727.29412-1-liq3ea@163.com>
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+---
+ hw/usb/hcd-ehci.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+--- a/hw/usb/hcd-ehci.c
++++ b/hw/usb/hcd-ehci.c
+@@ -1374,7 +1374,10 @@ static int ehci_execute(EHCIPacket *p, c
+         spd = (p->pid == USB_TOKEN_IN && NLPTR_TBIT(p->qtd.altnext) == 0);
+         usb_packet_setup(&p->packet, p->pid, ep, 0, p->qtdaddr, spd,
+                          (p->qtd.token & QTD_TOKEN_IOC) != 0);
+-        usb_packet_map(&p->packet, &p->sgl);
++        if (usb_packet_map(&p->packet, &p->sgl)) {
++            qemu_sglist_destroy(&p->sgl);
++            return -1;
++        }
+         p->async = EHCI_ASYNC_INITIALIZED;
+     }
+ 
+@@ -1453,7 +1456,10 @@ static int ehci_process_itd(EHCIState *e
+             if (ep && ep->type == USB_ENDPOINT_XFER_ISOC) {
+                 usb_packet_setup(&ehci->ipacket, pid, ep, 0, addr, false,
+                                  (itd->transact[i] & ITD_XACT_IOC) != 0);
+-                usb_packet_map(&ehci->ipacket, &ehci->isgl);
++                if (usb_packet_map(&ehci->ipacket, &ehci->isgl)) {
++                    qemu_sglist_destroy(&ehci->isgl);
++                    return -1;
++                }
+                 usb_handle_packet(dev, &ehci->ipacket);
+                 usb_packet_unmap(&ehci->ipacket, &ehci->isgl);
+             } else {

--- a/debian/patches/ubuntu/CVE-2020-27616.patch
+++ b/debian/patches/ubuntu/CVE-2020-27616.patch
@@ -1,0 +1,48 @@
+From ca1f9cbfdce4d63b10d57de80fef89a89d92a540 Mon Sep 17 00:00:00 2001
+From: Prasad J Pandit <pjp@fedoraproject.org>
+Date: Wed, 21 Oct 2020 16:08:18 +0530
+Subject: [PATCH] ati: check x y display parameter values
+
+The source and destination x,y display parameters in ati_2d_blt()
+may run off the vga limits if either of s->regs.[src|dst]_[xy] is
+zero. Check the parameter values to avoid potential crash.
+
+Reported-by: Gaoning Pan <pgn@zju.edu.cn>
+Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
+Message-id: 20201021103818.1704030-1-ppandit@redhat.com
+Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+---
+ hw/display/ati_2d.c | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/hw/display/ati_2d.c b/hw/display/ati_2d.c
+index 23a8ae0..4dc10ea 100644
+--- a/hw/display/ati_2d.c
++++ b/hw/display/ati_2d.c
+@@ -75,8 +75,9 @@ void ati_2d_blt(ATIVGAState *s)
+         dst_stride *= bpp;
+     }
+     uint8_t *end = s->vga.vram_ptr + s->vga.vram_size;
+-    if (dst_bits >= end || dst_bits + dst_x + (dst_y + s->regs.dst_height) *
+-        dst_stride >= end) {
++    if (dst_x > 0x3fff || dst_y > 0x3fff || dst_bits >= end
++        || dst_bits + dst_x
++         + (dst_y + s->regs.dst_height) * dst_stride >= end) {
+         qemu_log_mask(LOG_UNIMP, "blt outside vram not implemented\n");
+         return;
+     }
+@@ -107,8 +108,9 @@ void ati_2d_blt(ATIVGAState *s)
+             src_bits += s->regs.crtc_offset & 0x07ffffff;
+             src_stride *= bpp;
+         }
+-        if (src_bits >= end || src_bits + src_x +
+-            (src_y + s->regs.dst_height) * src_stride >= end) {
++        if (src_x > 0x3fff || src_y > 0x3fff || src_bits >= end
++            || src_bits + src_x
++             + (src_y + s->regs.dst_height) * src_stride >= end) {
+             qemu_log_mask(LOG_UNIMP, "blt outside vram not implemented\n");
+             return;
+         }
+-- 
+1.8.3.1
+

--- a/debian/patches/ubuntu/CVE-2020-27617.patch
+++ b/debian/patches/ubuntu/CVE-2020-27617.patch
@@ -1,0 +1,44 @@
+From 7564bf7701f00214cdc8a678a9f7df765244def1 Mon Sep 17 00:00:00 2001
+From: Prasad J Pandit <pjp@fedoraproject.org>
+Date: Wed, 21 Oct 2020 11:35:50 +0530
+Subject: [PATCH] net: remove an assert call in eth_get_gso_type
+
+eth_get_gso_type() routine returns segmentation offload type based on
+L3 protocol type. It calls g_assert_not_reached if L3 protocol is
+unknown, making the following return statement unreachable. Remove the
+g_assert call, it maybe triggered by a guest user.
+
+Reported-by: Gaoning Pan <pgn@zju.edu.cn>
+Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
+Signed-off-by: Jason Wang <jasowang@redhat.com>
+---
+ net/eth.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/net/eth.c b/net/eth.c
+index 0c1d413..1e0821c 100644
+--- a/net/eth.c
++++ b/net/eth.c
+@@ -16,6 +16,7 @@
+  */
+ 
+ #include "qemu/osdep.h"
++#include "qemu/log.h"
+ #include "net/eth.h"
+ #include "net/checksum.h"
+ #include "net/tap.h"
+@@ -71,9 +72,8 @@ eth_get_gso_type(uint16_t l3_proto, uint8_t *l3_hdr, uint8_t l4proto)
+             return VIRTIO_NET_HDR_GSO_TCPV6 | ecn_state;
+         }
+     }
+-
+-    /* Unsupported offload */
+-    g_assert_not_reached();
++    qemu_log_mask(LOG_UNIMP, "%s: probably not GSO frame, "
++        "unknown L3 protocol: 0x%04"PRIx16"\n", __func__, l3_proto);
+ 
+     return VIRTIO_NET_HDR_GSO_NONE | ecn_state;
+ }
+-- 
+1.8.3.1
+

--- a/debian/patches/ubuntu/define-ubuntu-machine-types.patch
+++ b/debian/patches/ubuntu/define-ubuntu-machine-types.patch
@@ -97,7 +97,7 @@ Forward-info: downstream decision
 
 --- a/hw/i386/pc_piix.c
 +++ b/hw/i386/pc_piix.c
-@@ -429,7 +429,7 @@ static void pc_i440fx_4_2_machine_option
+@@ -428,7 +428,7 @@ static void pc_i440fx_4_2_machine_option
      PCMachineClass *pcmc = PC_MACHINE_CLASS(m);
      pc_i440fx_machine_options(m);
      m->alias = "pc";
@@ -106,7 +106,7 @@ Forward-info: downstream decision
      pcmc->default_cpu_version = 1;
  }
  
-@@ -1026,3 +1026,175 @@ static void xenfv_machine_options(Machin
+@@ -1025,3 +1025,180 @@ static void xenfv_machine_options(Machin
  DEFINE_PC_MACHINE(xenfv, "xenfv", pc_xen_hvm_init,
                    xenfv_machine_options);
  #endif
@@ -261,15 +261,20 @@ Forward-info: downstream decision
 + * moving between those version references.
 + * This introduces pc_i440fx_wily_machine_options which encapsulates the
 + * old behavior as it was (this is the purpose of machine types).
++ *
++ * Further bug 1902654 identified issues due to the upstream rework of types
++ * that made the wily type change some attributes in >=Eoan.
++ * As we did in Bionic for 1829868 we need to use a 2_4/2_3 hybrid type to
++ * match what was initially shipped.
 + */
 +static void pc_i440fx_wily_machine_options(MachineClass *m)
 +{
 +    PCMachineClass *pcmc = PC_MACHINE_CLASS(m);
-+    pc_i440fx_2_4_machine_options(m);
++    pc_i440fx_2_5_machine_options(m);
 +    m->hw_version = "2.4.0";
 +    pcmc->broken_reserved_end = true;
-+    compat_props_add(m->compat_props, hw_compat_2_3, hw_compat_2_3_len);
-+    compat_props_add(m->compat_props, pc_compat_2_3, pc_compat_2_3_len);
++    compat_props_add(m->compat_props, hw_compat_2_4_wily, hw_compat_2_4_wily_len);
++    compat_props_add(m->compat_props, pc_compat_2_4, pc_compat_2_4_len);
 +}
 +
 +static void pc_wily_machine_options(MachineClass *m)
@@ -630,4 +635,54 @@ Forward-info: downstream decision
 +
  extern GlobalProperty pc_compat_3_1[];
  extern const size_t pc_compat_3_1_len;
+ 
+--- a/hw/core/machine.c
++++ b/hw/core/machine.c
+@@ -136,16 +136,28 @@ GlobalProperty hw_compat_2_5[] = {
+ };
+ const size_t hw_compat_2_5_len = G_N_ELEMENTS(hw_compat_2_5);
+ 
++#define HW_COMPAT_2_4_DEFS \
++    { "virtio-blk-device", "scsi", "true" }, \
++    { "e1000", "extra_mac_registers", "off" }, \
++    { "virtio-pci", "x-disable-pcie", "on" }, \
++    { "virtio-pci", "migrate-extra", "off" }, \
++    { "fw_cfg_mem", "dma_enabled", "off" }, \
++    { "fw_cfg_io", "dma_enabled", "off" },
++
+ GlobalProperty hw_compat_2_4[] = {
+-    { "virtio-blk-device", "scsi", "true" },
+-    { "e1000", "extra_mac_registers", "off" },
+-    { "virtio-pci", "x-disable-pcie", "on" },
+-    { "virtio-pci", "migrate-extra", "off" },
+-    { "fw_cfg_mem", "dma_enabled", "off" },
+-    { "fw_cfg_io", "dma_enabled", "off" }
++    HW_COMPAT_2_4_DEFS
+ };
+ const size_t hw_compat_2_4_len = G_N_ELEMENTS(hw_compat_2_4);
+ 
++// workaround for bug 1902654 / 1829868, see pc_i440fx_wily_machine_options in hw/i386/pc_piix.c
++GlobalProperty hw_compat_2_4_wily[] = {
++    HW_COMPAT_2_4_DEFS
++    { "migration", "send-configuration", "off" },
++    { "migration", "send-section-footer", "off" },
++    { "migration", "store-global-state", "off" },
++};
++const size_t hw_compat_2_4_wily_len = G_N_ELEMENTS(hw_compat_2_4_wily);
++
+ GlobalProperty hw_compat_2_3[] = {
+     { "virtio-blk-pci", "any_layout", "off" },
+     { "virtio-balloon-pci", "any_layout", "off" },
+--- a/include/hw/boards.h
++++ b/include/hw/boards.h
+@@ -368,6 +368,10 @@ extern const size_t hw_compat_2_5_len;
+ extern GlobalProperty hw_compat_2_4[];
+ extern const size_t hw_compat_2_4_len;
+ 
++// workaround for bug 1902654 / 1829868, see pc_i440fx_wily_machine_options in hw/i386/pc_piix.c
++extern GlobalProperty hw_compat_2_4_wily[];
++extern const size_t hw_compat_2_4_wily_len;
++
+ extern GlobalProperty hw_compat_2_3[];
+ extern const size_t hw_compat_2_3_len;
  


### PR DESCRIPTION
This patch is needed to keep this package in sync with Ubuntu's

  *  Import 1:4.2-3ubuntu6.10
  *  Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
