### PR TITLE
Import 1:4.2-3ubuntu6.20

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+qemu (1:4.2-3ubuntu6.20+exo2) UNRELEASED; urgency=medium
+
+  * Import 1:4.2-3ubuntu6.20
+  * Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Wed, 09 Mar 2022 14:16:01 +0000
+
+qemu (1:4.2-3ubuntu6.20) focal; urgency=medium
+
+  * d/p/u/lp1953338-*: KVM hardware diagnose 318 data improvements
+    (LP: #1953338)
+
+ -- Christian Ehrhardt <christian.ehrhardt@canonical.com>  Mon, 24 Jan 2022 11:37:27 +0100
+
 qemu (1:4.2-3ubuntu6.19+exo2) UNRELEASED; urgency=medium
 
   * Import 1:4.2-3ubuntu6.19

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -309,6 +309,15 @@ CVE-2021-20221.patch
 CVE-2021-20257.patch
 ubuntu/lp-1749393-linux-user-Reserve-space-for-brk.patch
 ubuntu/lp-1929926-target-s390x-Fix-translation-exception-on-illegal-in.patch
+ubuntu/lp1953338-01-s390-sclp-get-machine-once-during-read-scp-cpu-info.patch
+ubuntu/lp1953338-02-s390-sclp-rework-sclp-boundary-checks.patch
+ubuntu/lp1953338-03-s390-sclp-read-sccb-from-mem-based-on-provided-lengt.patch
+ubuntu/lp1953338-04-s390-sclp-check-sccb-len-before-filling-in-data.patch
+ubuntu/lp1953338-05-s390-sclp-use-cpu-offset-to-locate-cpu-entries.patch
+ubuntu/lp1953338-06-s390-sclp-add-extended-length-sccb-support-for-kvm-g.patch
+ubuntu/lp1953338-07-s390-guest-support-for-diagnose-0x318.patch
+ubuntu/lp1953338-08-s390x-pv-Remove-sclp-boundary-checks.patch
+ubuntu/lp1953338-09-s390x-pv-Fix-diag318-PV-fencing.patch
 
 # Exoscale
 exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch

--- a/debian/patches/ubuntu/lp1953338-01-s390-sclp-get-machine-once-during-read-scp-cpu-info.patch
+++ b/debian/patches/ubuntu/lp1953338-01-s390-sclp-get-machine-once-during-read-scp-cpu-info.patch
@@ -1,0 +1,65 @@
+From 29e86d94fd1745269523b42f81e4c6c1cae9b336 Mon Sep 17 00:00:00 2001
+From: Collin Walling <walling@linux.ibm.com>
+Date: Tue, 15 Sep 2020 15:44:09 -0400
+Subject: [PATCH 1/9] s390/sclp: get machine once during read scp/cpu info
+
+Functions within read scp/cpu info will need access to the machine
+state. Let's make a call to retrieve the machine state once and
+pass the appropriate data to the respective functions.
+
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+Reviewed-by: David Hildenbrand <david@redhat.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Reviewed-by: Janosch Frank <frankja@linux.ibm.com>
+Reviewed-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Claudio Imbrenda <imbrenda@linux.ibm.com>
+Message-Id: <20200915194416.107460-2-walling@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+Origin: upstream, https://git.qemu.org/?p=qemu.git;a=commit;h=912d70d2755cb9b3144eeed4014580ebc5485ce6
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ hw/s390x/sclp.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/hw/s390x/sclp.c b/hw/s390x/sclp.c
+index 1c380a49cc..be40e3534c 100644
+--- a/hw/s390x/sclp.c
++++ b/hw/s390x/sclp.c
+@@ -49,9 +49,8 @@ static inline bool sclp_command_code_valid(uint32_t code)
+     return false;
+ }
+ 
+-static void prepare_cpu_entries(SCLPDevice *sclp, CPUEntry *entry, int *count)
++static void prepare_cpu_entries(MachineState *ms, CPUEntry *entry, int *count)
+ {
+-    MachineState *ms = MACHINE(qdev_get_machine());
+     uint8_t features[SCCB_CPU_FEATURE_LEN] = { 0 };
+     int i;
+ 
+@@ -77,7 +76,7 @@ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+     IplParameterBlock *ipib = s390_ipl_get_iplb();
+ 
+     /* CPU information */
+-    prepare_cpu_entries(sclp, read_info->entries, &cpu_count);
++    prepare_cpu_entries(machine, read_info->entries, &cpu_count);
+     read_info->entries_cpu = cpu_to_be16(cpu_count);
+     read_info->offset_cpu = cpu_to_be16(offsetof(ReadInfo, entries));
+     read_info->highest_cpu = cpu_to_be16(machine->smp.max_cpus - 1);
+@@ -132,10 +131,11 @@ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+ /* Provide information about the CPU */
+ static void sclp_read_cpu_info(SCLPDevice *sclp, SCCB *sccb)
+ {
++    MachineState *machine = MACHINE(qdev_get_machine());
+     ReadCpuInfo *cpu_info = (ReadCpuInfo *) sccb;
+     int cpu_count;
+ 
+-    prepare_cpu_entries(sclp, cpu_info->entries, &cpu_count);
++    prepare_cpu_entries(machine, cpu_info->entries, &cpu_count);
+     cpu_info->nr_configured = cpu_to_be16(cpu_count);
+     cpu_info->offset_configured = cpu_to_be16(offsetof(ReadCpuInfo, entries));
+     cpu_info->nr_standby = cpu_to_be16(0);
+-- 
+2.31.1
+

--- a/debian/patches/ubuntu/lp1953338-02-s390-sclp-rework-sclp-boundary-checks.patch
+++ b/debian/patches/ubuntu/lp1953338-02-s390-sclp-rework-sclp-boundary-checks.patch
@@ -1,0 +1,70 @@
+From e17df6f1203134de3fc75e8cd1c4e767de8a97d4 Mon Sep 17 00:00:00 2001
+From: Collin Walling <walling@linux.ibm.com>
+Date: Tue, 15 Sep 2020 15:44:10 -0400
+Subject: [PATCH 2/9] s390/sclp: rework sclp boundary checks
+
+Rework the SCLP boundary check to account for different SCLP commands
+(eventually) allowing different boundary sizes.
+
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+Reviewed-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Acked-by: Janosch Frank <frankja@linux.ibm.com>
+Reviewed-by: Claudio Imbrenda <imbrenda@linux.ibm.com>
+Message-Id: <20200915194416.107460-3-walling@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+Origin: upstream, https://git.qemu.org/?p=qemu.git;a=commit;h=db13387ca01a69d870cc16dd232375c2603596f2
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ hw/s390x/sclp.c | 19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/hw/s390x/sclp.c b/hw/s390x/sclp.c
+index be40e3534c..ff2734920a 100644
+--- a/hw/s390x/sclp.c
++++ b/hw/s390x/sclp.c
+@@ -49,6 +49,18 @@ static inline bool sclp_command_code_valid(uint32_t code)
+     return false;
+ }
+ 
++static bool sccb_verify_boundary(uint64_t sccb_addr, uint16_t sccb_len)
++{
++    uint64_t sccb_max_addr = sccb_addr + sccb_len - 1;
++    uint64_t sccb_boundary = (sccb_addr & PAGE_MASK) + PAGE_SIZE;
++
++    if (sccb_max_addr < sccb_boundary) {
++        return true;
++    }
++
++    return false;
++}
++
+ static void prepare_cpu_entries(MachineState *ms, CPUEntry *entry, int *count)
+ {
+     uint8_t features[SCCB_CPU_FEATURE_LEN] = { 0 };
+@@ -229,6 +241,11 @@ int sclp_service_call_protected(CPUS390XState *env, uint64_t sccb,
+         goto out_write;
+     }
+ 
++    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb.h.length))) {
++        work_sccb.h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
++        goto out_write;
++    }
++
+     sclp_c->execute(sclp, &work_sccb, code);
+ out_write:
+     s390_cpu_pv_mem_write(env_archcpu(env), 0, &work_sccb,
+@@ -279,7 +296,7 @@ int sclp_service_call(CPUS390XState *env, uint64_t sccb, uint32_t code)
+         goto out_write;
+     }
+ 
+-    if ((sccb + be16_to_cpu(work_sccb.h.length)) > ((sccb & PAGE_MASK) + PAGE_SIZE)) {
++    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb.h.length))) {
+         work_sccb.h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
+         goto out_write;
+     }
+-- 
+2.31.1
+

--- a/debian/patches/ubuntu/lp1953338-03-s390-sclp-read-sccb-from-mem-based-on-provided-lengt.patch
+++ b/debian/patches/ubuntu/lp1953338-03-s390-sclp-read-sccb-from-mem-based-on-provided-lengt.patch
@@ -1,0 +1,166 @@
+From e7904f474ef824ba1419c4cf734058f322ffd09e Mon Sep 17 00:00:00 2001
+From: Collin Walling <walling@linux.ibm.com>
+Date: Tue, 15 Sep 2020 15:44:11 -0400
+Subject: [PATCH 3/9] s390/sclp: read sccb from mem based on provided length
+
+The header contained within the SCCB passed to the SCLP service call
+contains the actual length of the SCCB. Instead of allocating a static
+4K size for the work sccb, let's allow for a variable size determined
+by the value in the header. The proper checks are already in place to
+ensure the SCCB length is sufficent to store a full response and that
+the length does not cross any explicitly-set boundaries.
+
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Reviewed-by: Claudio Imbrenda <imbrenda@linux.ibm.com>
+Message-Id: <20200915194416.107460-4-walling@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+(backported from commit c1db53a5910f988eeb32f031c53a50f3373fd824)
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+
+Origin: backport, https://git.qemu.org/?p=qemu.git;a=commit;h=c1db53a5910f988eeb32f031c53a50f3373fd824
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ hw/s390x/event-facility.c |  2 +-
+ hw/s390x/sclp.c           | 57 ++++++++++++++++++++++-----------------
+ include/hw/s390x/sclp.h   |  2 +-
+ 3 files changed, 34 insertions(+), 27 deletions(-)
+
+diff --git a/hw/s390x/event-facility.c b/hw/s390x/event-facility.c
+index 66205697ae..8aa7017f06 100644
+--- a/hw/s390x/event-facility.c
++++ b/hw/s390x/event-facility.c
+@@ -215,7 +215,7 @@ static uint16_t handle_sccb_read_events(SCLPEventFacility *ef, SCCB *sccb,
+ 
+     event_buf = &red->ebh;
+     event_buf->length = 0;
+-    slen = sizeof(sccb->data);
++    slen = sccb_data_len(sccb);
+ 
+     rc = SCLP_RC_NO_EVENT_BUFFERS_STORED;
+ 
+diff --git a/hw/s390x/sclp.c b/hw/s390x/sclp.c
+index ff2734920a..a57c94f201 100644
+--- a/hw/s390x/sclp.c
++++ b/hw/s390x/sclp.c
+@@ -231,25 +231,29 @@ int sclp_service_call_protected(CPUS390XState *env, uint64_t sccb,
+ {
+     SCLPDevice *sclp = get_sclp_device();
+     SCLPDeviceClass *sclp_c = SCLP_GET_CLASS(sclp);
+-    SCCB work_sccb;
+-    hwaddr sccb_len = sizeof(SCCB);
++    SCCBHeader header;
++    g_autofree SCCB *work_sccb = NULL;
+ 
+-    s390_cpu_pv_mem_read(env_archcpu(env), 0, &work_sccb, sccb_len);
++    s390_cpu_pv_mem_read(env_archcpu(env), 0, &header, sizeof(SCCBHeader));
++
++    work_sccb = g_malloc0(be16_to_cpu(header.length));
++    s390_cpu_pv_mem_read(env_archcpu(env), 0, work_sccb,
++                         be16_to_cpu(header.length));
+ 
+     if (!sclp_command_code_valid(code)) {
+-        work_sccb.h.response_code = cpu_to_be16(SCLP_RC_INVALID_SCLP_COMMAND);
++        work_sccb->h.response_code = cpu_to_be16(SCLP_RC_INVALID_SCLP_COMMAND);
+         goto out_write;
+     }
+ 
+-    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb.h.length))) {
+-        work_sccb.h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
++    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb->h.length))) {
++        work_sccb->h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
+         goto out_write;
+     }
+ 
+-    sclp_c->execute(sclp, &work_sccb, code);
++    sclp_c->execute(sclp, work_sccb, code);
+ out_write:
+-    s390_cpu_pv_mem_write(env_archcpu(env), 0, &work_sccb,
+-                          be16_to_cpu(work_sccb.h.length));
++    s390_cpu_pv_mem_write(env_archcpu(env), 0, work_sccb,
++                          be16_to_cpu(work_sccb->h.length));
+     sclp_c->service_interrupt(sclp, SCLP_PV_DUMMY_ADDR);
+     return 0;
+ }
+@@ -258,10 +262,9 @@ int sclp_service_call(CPUS390XState *env, uint64_t sccb, uint32_t code)
+ {
+     SCLPDevice *sclp = get_sclp_device();
+     SCLPDeviceClass *sclp_c = SCLP_GET_CLASS(sclp);
++    SCCBHeader header;
++    g_autofree SCCB *work_sccb = NULL;
+     int r = 0;
+-    SCCB work_sccb;
+-
+-    hwaddr sccb_len = sizeof(SCCB);
+ 
+     /* first some basic checks on program checks */
+     if (env->psw.mask & PSW_MASK_PSTATE) {
+@@ -278,33 +281,37 @@ int sclp_service_call(CPUS390XState *env, uint64_t sccb, uint32_t code)
+         goto out;
+     }
+ 
++    /* the header contains the actual length of the sccb */
++    cpu_physical_memory_read(sccb, &header, sizeof(SCCBHeader));
++
++    /* Valid sccb sizes */
++    if (be16_to_cpu(header.length) < sizeof(SCCBHeader)) {
++        r = -PGM_SPECIFICATION;
++	goto out;
++    }
++
+     /*
+      * we want to work on a private copy of the sccb, to prevent guests
+      * from playing dirty tricks by modifying the memory content after
+      * the host has checked the values
+      */
+-    cpu_physical_memory_read(sccb, &work_sccb, sccb_len);
+-
+-    /* Valid sccb sizes */
+-    if (be16_to_cpu(work_sccb.h.length) < sizeof(SCCBHeader)) {
+-        r = -PGM_SPECIFICATION;
+-        goto out;
+-    }
++    work_sccb = g_malloc0(be16_to_cpu(header.length));
++    cpu_physical_memory_read(sccb, work_sccb, be16_to_cpu(header.length));
+ 
+     if (!sclp_command_code_valid(code)) {
+-        work_sccb.h.response_code = cpu_to_be16(SCLP_RC_INVALID_SCLP_COMMAND);
++        work_sccb->h.response_code = cpu_to_be16(SCLP_RC_INVALID_SCLP_COMMAND);
+         goto out_write;
+     }
+ 
+-    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb.h.length))) {
+-        work_sccb.h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
++    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb->h.length))) {
++        work_sccb->h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
+         goto out_write;
+     }
+ 
+-    sclp_c->execute(sclp, &work_sccb, code);
++    sclp_c->execute(sclp, work_sccb, code);
+ out_write:
+-    cpu_physical_memory_write(sccb, &work_sccb,
+-                              be16_to_cpu(work_sccb.h.length));
++    cpu_physical_memory_write(sccb, work_sccb,
++                              be16_to_cpu(work_sccb->h.length));
+ 
+     sclp_c->service_interrupt(sclp, sccb);
+ 
+diff --git a/include/hw/s390x/sclp.h b/include/hw/s390x/sclp.h
+index c0a3faa37d..55f53a4654 100644
+--- a/include/hw/s390x/sclp.h
++++ b/include/hw/s390x/sclp.h
+@@ -177,7 +177,7 @@ typedef struct IoaCfgSccb {
+ 
+ typedef struct SCCB {
+     SCCBHeader h;
+-    char data[SCCB_DATA_LEN];
++    char data[];
+  } QEMU_PACKED SCCB;
+ 
+ #define TYPE_SCLP "sclp"
+-- 
+2.31.1
+

--- a/debian/patches/ubuntu/lp1953338-04-s390-sclp-check-sccb-len-before-filling-in-data.patch
+++ b/debian/patches/ubuntu/lp1953338-04-s390-sclp-check-sccb-len-before-filling-in-data.patch
@@ -1,0 +1,96 @@
+From 91be7da5ee7f350646f01226355a1df104b7ba72 Mon Sep 17 00:00:00 2001
+From: Collin Walling <walling@linux.ibm.com>
+Date: Tue, 15 Sep 2020 15:44:12 -0400
+Subject: [PATCH 4/9] s390/sclp: check sccb len before filling in data
+
+The SCCB must be checked for a sufficient length before it is filled
+with any data. If the length is insufficient, then the SCLP command
+is suppressed and the proper response code is set in the SCCB header.
+
+While we're at it, let's cleanup the length check by placing the
+calculation inside a macro.
+
+Fixes: 832be0d8a3bb ("s390x: sclp: Report insufficient SCCB length")
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+Reviewed-by: Janosch Frank <frankja@linux.ibm.com>
+Reviewed-by: David Hildenbrand <david@redhat.com>
+Reviewed-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Reviewed-by: Claudio Imbrenda <imbrenda@linux.ibm.com>
+Message-Id: <20200915194416.107460-5-walling@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+Origin: upstream, https://git.qemu.org/?p=qemu.git;a=commit;h=0260b97824495ebfacfa8bbae0be10b0ef986bf6
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ hw/s390x/sclp.c | 26 ++++++++++++++------------
+ 1 file changed, 14 insertions(+), 12 deletions(-)
+
+diff --git a/hw/s390x/sclp.c b/hw/s390x/sclp.c
+index a57c94f201..0cb9c72313 100644
+--- a/hw/s390x/sclp.c
++++ b/hw/s390x/sclp.c
+@@ -78,6 +78,8 @@ static void prepare_cpu_entries(MachineState *ms, CPUEntry *entry, int *count)
+     }
+ }
+ 
++#define SCCB_REQ_LEN(s, max_cpus) (sizeof(s) + max_cpus * sizeof(CPUEntry))
++
+ /* Provide information about the configuration, CPUs and storage */
+ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+ {
+@@ -86,6 +88,12 @@ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+     int cpu_count;
+     int rnsize, rnmax;
+     IplParameterBlock *ipib = s390_ipl_get_iplb();
++    int required_len = SCCB_REQ_LEN(ReadInfo, machine->possible_cpus->len);
++
++    if (be16_to_cpu(sccb->h.length) < required_len) {
++        sccb->h.response_code = cpu_to_be16(SCLP_RC_INSUFFICIENT_SCCB_LENGTH);
++        return;
++    }
+ 
+     /* CPU information */
+     prepare_cpu_entries(machine, read_info->entries, &cpu_count);
+@@ -95,12 +103,6 @@ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+ 
+     read_info->ibc_val = cpu_to_be32(s390_get_ibc_val());
+ 
+-    if (be16_to_cpu(sccb->h.length) <
+-            (sizeof(ReadInfo) + cpu_count * sizeof(CPUEntry))) {
+-        sccb->h.response_code = cpu_to_be16(SCLP_RC_INSUFFICIENT_SCCB_LENGTH);
+-        return;
+-    }
+-
+     /* Configuration Characteristic (Extension) */
+     s390_get_feat_block(S390_FEAT_TYPE_SCLP_CONF_CHAR,
+                          read_info->conf_char);
+@@ -146,18 +148,18 @@ static void sclp_read_cpu_info(SCLPDevice *sclp, SCCB *sccb)
+     MachineState *machine = MACHINE(qdev_get_machine());
+     ReadCpuInfo *cpu_info = (ReadCpuInfo *) sccb;
+     int cpu_count;
++    int required_len = SCCB_REQ_LEN(ReadCpuInfo, machine->possible_cpus->len);
++
++    if (be16_to_cpu(sccb->h.length) < required_len) {
++        sccb->h.response_code = cpu_to_be16(SCLP_RC_INSUFFICIENT_SCCB_LENGTH);
++        return;
++    }
+ 
+     prepare_cpu_entries(machine, cpu_info->entries, &cpu_count);
+     cpu_info->nr_configured = cpu_to_be16(cpu_count);
+     cpu_info->offset_configured = cpu_to_be16(offsetof(ReadCpuInfo, entries));
+     cpu_info->nr_standby = cpu_to_be16(0);
+ 
+-    if (be16_to_cpu(sccb->h.length) <
+-            (sizeof(ReadCpuInfo) + cpu_count * sizeof(CPUEntry))) {
+-        sccb->h.response_code = cpu_to_be16(SCLP_RC_INSUFFICIENT_SCCB_LENGTH);
+-        return;
+-    }
+-
+     /* The standby offset is 16-byte for each CPU */
+     cpu_info->offset_standby = cpu_to_be16(cpu_info->offset_configured
+         + cpu_info->nr_configured*sizeof(CPUEntry));
+-- 
+2.31.1
+

--- a/debian/patches/ubuntu/lp1953338-05-s390-sclp-use-cpu-offset-to-locate-cpu-entries.patch
+++ b/debian/patches/ubuntu/lp1953338-05-s390-sclp-use-cpu-offset-to-locate-cpu-entries.patch
@@ -1,0 +1,57 @@
+From ad8b922ab3ce8e1c430be7764df96c866b1b42ad Mon Sep 17 00:00:00 2001
+From: Collin Walling <walling@linux.ibm.com>
+Date: Tue, 15 Sep 2020 15:44:13 -0400
+Subject: [PATCH 5/9] s390/sclp: use cpu offset to locate cpu entries
+
+The start of the CPU entry region in the Read SCP Info response data is
+denoted by the offset_cpu field. As such, QEMU needs to begin creating
+entries at this address.
+
+This is in preparation for when Read SCP Info inevitably introduces new
+bytes that push the start of the CPUEntry field further away.
+
+Read CPU Info is unlikely to ever change, so let's not bother
+accounting for the offset there.
+
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Reviewed-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Claudio Imbrenda <imbrenda@linux.ibm.com>
+Message-Id: <20200915194416.107460-6-walling@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+Origin: upstream, https://git.qemu.org/?p=qemu.git;a=commit;h=1a7a568859473b1cda39a015493c5c82bb200281
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ hw/s390x/sclp.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/hw/s390x/sclp.c b/hw/s390x/sclp.c
+index 0cb9c72313..6745bfdf1e 100644
+--- a/hw/s390x/sclp.c
++++ b/hw/s390x/sclp.c
+@@ -89,6 +89,8 @@ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+     int rnsize, rnmax;
+     IplParameterBlock *ipib = s390_ipl_get_iplb();
+     int required_len = SCCB_REQ_LEN(ReadInfo, machine->possible_cpus->len);
++    int offset_cpu = offsetof(ReadInfo, entries);
++    CPUEntry *entries_start = (void *)sccb + offset_cpu;
+ 
+     if (be16_to_cpu(sccb->h.length) < required_len) {
+         sccb->h.response_code = cpu_to_be16(SCLP_RC_INSUFFICIENT_SCCB_LENGTH);
+@@ -96,9 +98,9 @@ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+     }
+ 
+     /* CPU information */
+-    prepare_cpu_entries(machine, read_info->entries, &cpu_count);
++    prepare_cpu_entries(machine, entries_start, &cpu_count);
+     read_info->entries_cpu = cpu_to_be16(cpu_count);
+-    read_info->offset_cpu = cpu_to_be16(offsetof(ReadInfo, entries));
++    read_info->offset_cpu = cpu_to_be16(offset_cpu);
+     read_info->highest_cpu = cpu_to_be16(machine->smp.max_cpus - 1);
+ 
+     read_info->ibc_val = cpu_to_be32(s390_get_ibc_val());
+-- 
+2.31.1
+

--- a/debian/patches/ubuntu/lp1953338-06-s390-sclp-add-extended-length-sccb-support-for-kvm-g.patch
+++ b/debian/patches/ubuntu/lp1953338-06-s390-sclp-add-extended-length-sccb-support-for-kvm-g.patch
@@ -1,0 +1,212 @@
+From 318cdc8eb9a20a1999719a10154fbfeb604a2242 Mon Sep 17 00:00:00 2001
+From: Collin Walling <walling@linux.ibm.com>
+Date: Tue, 15 Sep 2020 15:44:14 -0400
+Subject: [PATCH 6/9] s390/sclp: add extended-length sccb support for kvm guest
+
+As more features and facilities are added to the Read SCP Info (RSCPI)
+response, more space is required to store them. The space used to store
+these new features intrudes on the space originally used to store CPU
+entries. This means as more features and facilities are added to the
+RSCPI response, less space can be used to store CPU entries.
+
+With the Extended-Length SCCB (ELS) facility, a KVM guest can execute
+the RSCPI command and determine if the SCCB is large enough to store a
+complete reponse. If it is not large enough, then the required length
+will be set in the SCCB header.
+
+The caller of the SCLP command is responsible for creating a
+large-enough SCCB to store a complete response. Proper checking should
+be in place, and the caller should execute the command once-more with
+the large-enough SCCB.
+
+This facility also enables an extended SCCB for the Read CPU Info
+(RCPUI) command.
+
+When this facility is enabled, the boundary violation response cannot
+be a result from the RSCPI, RSCPI Forced, or RCPUI commands.
+
+In order to tolerate kernels that do not yet have full support for this
+feature, a "fixed" offset to the start of the CPU Entries within the
+Read SCP Info struct is set to allow for the original 248 max entries
+when this feature is disabled.
+
+Additionally, this is introduced as a CPU feature to protect the guest
+from migrating to a machine that does not support storing an extended
+SCCB. This could otherwise hinder the VM from being able to read all
+available CPU entries after migration (such as during re-ipl).
+
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Acked-by: Cornelia Huck <cohuck@redhat.com>
+Reviewed-by: Claudio Imbrenda <imbrenda@linux.ibm.com>
+Message-Id: <20200915194416.107460-7-walling@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+(backported from commit 1ecd6078f587cfadda8edc93d45b5072e35f2d17)
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+
+Origin: backport, https://git.qemu.org/?p=qemu.git;a=commit;h=1ecd6078f587cfadda8edc93d45b5072e35f2d17
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ hw/s390x/sclp.c                     | 43 +++++++++++++++++++++++++----
+ include/hw/s390x/sclp.h             |  1 +
+ target/s390x/cpu_features_def.inc.h |  1 +
+ target/s390x/gen-features.c         |  1 +
+ target/s390x/kvm.c                  |  8 ++++++
+ 5 files changed, 48 insertions(+), 6 deletions(-)
+
+diff --git a/hw/s390x/sclp.c b/hw/s390x/sclp.c
+index 6745bfdf1e..3a08d6ff45 100644
+--- a/hw/s390x/sclp.c
++++ b/hw/s390x/sclp.c
+@@ -49,13 +49,30 @@ static inline bool sclp_command_code_valid(uint32_t code)
+     return false;
+ }
+ 
+-static bool sccb_verify_boundary(uint64_t sccb_addr, uint16_t sccb_len)
++static bool sccb_verify_boundary(uint64_t sccb_addr, uint16_t sccb_len,
++                                 uint32_t code)
+ {
+     uint64_t sccb_max_addr = sccb_addr + sccb_len - 1;
+     uint64_t sccb_boundary = (sccb_addr & PAGE_MASK) + PAGE_SIZE;
+ 
+-    if (sccb_max_addr < sccb_boundary) {
+-        return true;
++    switch (code & SCLP_CMD_CODE_MASK) {
++    case SCLP_CMDW_READ_SCP_INFO:
++    case SCLP_CMDW_READ_SCP_INFO_FORCED:
++    case SCLP_CMDW_READ_CPU_INFO:
++        /*
++         * An extended-length SCCB is only allowed for Read SCP/CPU Info and
++         * is allowed to exceed the 4k boundary. The respective commands will
++         * set the length field to the required length if an insufficient
++         * SCCB length is provided.
++         */
++        if (s390_has_feat(S390_FEAT_EXTENDED_LENGTH_SCCB)) {
++            return true;
++        }
++        /* fallthrough */
++    default:
++        if (sccb_max_addr < sccb_boundary) {
++            return true;
++        }
+     }
+ 
+     return false;
+@@ -80,6 +97,12 @@ static void prepare_cpu_entries(MachineState *ms, CPUEntry *entry, int *count)
+ 
+ #define SCCB_REQ_LEN(s, max_cpus) (sizeof(s) + max_cpus * sizeof(CPUEntry))
+ 
++static inline bool ext_len_sccb_supported(SCCBHeader header)
++{
++    return s390_has_feat(S390_FEAT_EXTENDED_LENGTH_SCCB) &&
++           header.control_mask[2] & SCLP_VARIABLE_LENGTH_RESPONSE;
++}
++
+ /* Provide information about the configuration, CPUs and storage */
+ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+ {
+@@ -89,10 +112,15 @@ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+     int rnsize, rnmax;
+     IplParameterBlock *ipib = s390_ipl_get_iplb();
+     int required_len = SCCB_REQ_LEN(ReadInfo, machine->possible_cpus->len);
+-    int offset_cpu = offsetof(ReadInfo, entries);
++    int offset_cpu = s390_has_feat(S390_FEAT_EXTENDED_LENGTH_SCCB) ?
++                     offsetof(ReadInfo, entries) :
++                     SCLP_READ_SCP_INFO_FIXED_CPU_OFFSET;
+     CPUEntry *entries_start = (void *)sccb + offset_cpu;
+ 
+     if (be16_to_cpu(sccb->h.length) < required_len) {
++        if (ext_len_sccb_supported(sccb->h)) {
++            sccb->h.length = cpu_to_be16(required_len);
++        }
+         sccb->h.response_code = cpu_to_be16(SCLP_RC_INSUFFICIENT_SCCB_LENGTH);
+         return;
+     }
+@@ -153,6 +181,9 @@ static void sclp_read_cpu_info(SCLPDevice *sclp, SCCB *sccb)
+     int required_len = SCCB_REQ_LEN(ReadCpuInfo, machine->possible_cpus->len);
+ 
+     if (be16_to_cpu(sccb->h.length) < required_len) {
++        if (ext_len_sccb_supported(sccb->h)) {
++            sccb->h.length = cpu_to_be16(required_len);
++        }
+         sccb->h.response_code = cpu_to_be16(SCLP_RC_INSUFFICIENT_SCCB_LENGTH);
+         return;
+     }
+@@ -249,7 +280,7 @@ int sclp_service_call_protected(CPUS390XState *env, uint64_t sccb,
+         goto out_write;
+     }
+ 
+-    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb->h.length))) {
++    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb->h.length), code)) {
+         work_sccb->h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
+         goto out_write;
+     }
+@@ -307,7 +338,7 @@ int sclp_service_call(CPUS390XState *env, uint64_t sccb, uint32_t code)
+         goto out_write;
+     }
+ 
+-    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb->h.length))) {
++    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb->h.length), code)) {
+         work_sccb->h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
+         goto out_write;
+     }
+diff --git a/include/hw/s390x/sclp.h b/include/hw/s390x/sclp.h
+index 55f53a4654..df2fa4169b 100644
+--- a/include/hw/s390x/sclp.h
++++ b/include/hw/s390x/sclp.h
+@@ -110,6 +110,7 @@ typedef struct CPUEntry {
+     uint8_t reserved1;
+ } QEMU_PACKED CPUEntry;
+ 
++#define SCLP_READ_SCP_INFO_FIXED_CPU_OFFSET     128
+ typedef struct ReadInfo {
+     SCCBHeader h;
+     uint16_t rnmax;
+diff --git a/target/s390x/cpu_features_def.inc.h b/target/s390x/cpu_features_def.inc.h
+index 60db28351d..3548d65a69 100644
+--- a/target/s390x/cpu_features_def.inc.h
++++ b/target/s390x/cpu_features_def.inc.h
+@@ -97,6 +97,7 @@ DEF_FEAT(GUARDED_STORAGE, "gs", STFL, 133, "Guarded-storage facility")
+ DEF_FEAT(VECTOR_PACKED_DECIMAL, "vxpd", STFL, 134, "Vector packed decimal facility")
+ DEF_FEAT(VECTOR_ENH, "vxeh", STFL, 135, "Vector enhancements facility")
+ DEF_FEAT(MULTIPLE_EPOCH, "mepoch", STFL, 139, "Multiple-epoch facility")
++DEF_FEAT(EXTENDED_LENGTH_SCCB, "els", STFL, 140, "Extended-length SCCB facility")
+ DEF_FEAT(TEST_PENDING_EXT_INTERRUPTION, "tpei", STFL, 144, "Test-pending-external-interruption facility")
+ DEF_FEAT(INSERT_REFERENCE_BITS_MULT, "irbm", STFL, 145, "Insert-reference-bits-multiple facility")
+ DEF_FEAT(MSA_EXT_8, "msa8-base", STFL, 146, "Message-security-assist-extension-8 facility (excluding subfunctions)")
+diff --git a/target/s390x/gen-features.c b/target/s390x/gen-features.c
+index 8ddeebc544..6857f657fb 100644
+--- a/target/s390x/gen-features.c
++++ b/target/s390x/gen-features.c
+@@ -522,6 +522,7 @@ static uint16_t full_GEN12_GA1[] = {
+     S390_FEAT_AP_QUEUE_INTERRUPT_CONTROL,
+     S390_FEAT_AP_FACILITIES_TEST,
+     S390_FEAT_AP,
++    S390_FEAT_EXTENDED_LENGTH_SCCB,
+ };
+ 
+ static uint16_t full_GEN12_GA2[] = {
+diff --git a/target/s390x/kvm.c b/target/s390x/kvm.c
+index 8b82e4c93d..550a988086 100644
+--- a/target/s390x/kvm.c
++++ b/target/s390x/kvm.c
+@@ -2438,6 +2438,14 @@ void kvm_s390_get_host_cpu_model(S390CPUModel *model, Error **errp)
+         KVM_S390_VM_CRYPTO_ENABLE_APIE)) {
+         set_bit(S390_FEAT_AP, model->features);
+     }
++
++    /*
++     * Extended-Length SCCB is handled entirely within QEMU.
++     * For PV guests this is completely fenced by the Ultravisor, as Service
++     * Call error checking and STFLE interpretation are handled via SIE.
++     */
++    set_bit(S390_FEAT_EXTENDED_LENGTH_SCCB, model->features);
++
+     /* strip of features that are not part of the maximum model */
+     bitmap_and(model->features, model->features, model->def->full_feat,
+                S390_FEAT_MAX);
+-- 
+2.31.1
+

--- a/debian/patches/ubuntu/lp1953338-07-s390-guest-support-for-diagnose-0x318.patch
+++ b/debian/patches/ubuntu/lp1953338-07-s390-guest-support-for-diagnose-0x318.patch
@@ -1,0 +1,319 @@
+From f2eae0b266e72d3443a39a45c35caafad0f46b5b Mon Sep 17 00:00:00 2001
+From: Collin Walling <walling@linux.ibm.com>
+Date: Tue, 15 Sep 2020 15:44:16 -0400
+Subject: [PATCH 7/9] s390: guest support for diagnose 0x318
+
+DIAGNOSE 0x318 (diag318) is an s390 instruction that allows the storage
+of diagnostic information that is collected by the firmware in the case
+of hardware/firmware service events.
+
+QEMU handles the instruction by storing the info in the CPU state. A
+subsequent register sync will communicate the data to the hypervisor.
+
+QEMU handles the migration via a VM State Description.
+
+This feature depends on the Extended-Length SCCB (els) feature. If
+els is not present, then a warning will be printed and the SCLP bit
+that allows the Linux kernel to execute the instruction will not be
+set.
+
+Availability of this instruction is determined by byte 134 (aka fac134)
+bit 0 of the SCLP Read Info block. This coincidentally expands into the
+space used for CPU entries, which means VMs running with the diag318
+capability may not be able to read information regarding all CPUs
+unless the guest kernel supports an extended-length SCCB.
+
+This feature is not supported in protected virtualization mode.
+
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+Acked-by: Janosch Frank <frankja@linux.ibm.com>
+Acked-by: Thomas Huth <thuth@redhat.com>
+Acked-by: David Hildenbrand <david@redhat.com>
+Acked-by: Claudio Imbrenda <imbrenda@linux.ibm.com>
+Message-Id: <20200915194416.107460-9-walling@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+(backported from commit fabdada9357b9cfd980c7744ddce47e34600bbef)
+Signed-off-by: Collin Walling <walling@linux.ibm.com>
+
+Origin: backport, https://git.qemu.org/?p=qemu.git;a=commit;h=fabdada9357b9cfd980c7744ddce47e34600bbef
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ hw/s390x/sclp.c                     |  5 ++++
+ include/hw/s390x/sclp.h             | 10 +++++++-
+ linux-headers/asm-s390/kvm.h        |  7 ++++--
+ linux-headers/linux/kvm.h           |  1 +
+ target/s390x/cpu.h                  |  2 ++
+ target/s390x/cpu_features.h         |  1 +
+ target/s390x/cpu_features_def.inc.h |  3 +++
+ target/s390x/cpu_models.c           |  1 +
+ target/s390x/gen-features.c         |  1 +
+ target/s390x/kvm.c                  | 39 +++++++++++++++++++++++++++++
+ target/s390x/machine.c              | 17 +++++++++++++
+ 11 files changed, 84 insertions(+), 3 deletions(-)
+
+diff --git a/hw/s390x/sclp.c b/hw/s390x/sclp.c
+index 3a08d6ff45..44ed0a810c 100644
+--- a/hw/s390x/sclp.c
++++ b/hw/s390x/sclp.c
+@@ -139,6 +139,11 @@ static void read_SCP_info(SCLPDevice *sclp, SCCB *sccb)
+     s390_get_feat_block(S390_FEAT_TYPE_SCLP_CONF_CHAR_EXT,
+                          read_info->conf_char_ext);
+ 
++    if (s390_has_feat(S390_FEAT_EXTENDED_LENGTH_SCCB)) {
++        s390_get_feat_block(S390_FEAT_TYPE_SCLP_FAC134,
++                            &read_info->fac134);
++    }
++
+     read_info->facilities = cpu_to_be64(SCLP_HAS_CPU_INFO |
+                                         SCLP_HAS_IOA_RECONFIG);
+ 
+diff --git a/include/hw/s390x/sclp.h b/include/hw/s390x/sclp.h
+index df2fa4169b..1fd63cb84d 100644
+--- a/include/hw/s390x/sclp.h
++++ b/include/hw/s390x/sclp.h
+@@ -133,7 +133,15 @@ typedef struct ReadInfo {
+     uint16_t highest_cpu;
+     uint8_t  _reserved5[124 - 122];     /* 122-123 */
+     uint32_t hmfai;
+-    struct CPUEntry entries[0];
++    uint8_t  _reserved7[134 - 128];     /* 128-133 */
++    uint8_t  fac134;
++    uint8_t  _reserved8[144 - 135];     /* 135-143 */
++    struct CPUEntry entries[];
++    /*
++     * When the Extended-Length SCCB (ELS) feature is enabled the
++     * start of the entries field begins at an offset denoted by the
++     * offset_cpu field, otherwise it's at an offset of 128.
++     */
+ } QEMU_PACKED ReadInfo;
+ 
+ typedef struct ReadCpuInfo {
+diff --git a/linux-headers/asm-s390/kvm.h b/linux-headers/asm-s390/kvm.h
+index 0138ccb0d8..a319345ae7 100644
+--- a/linux-headers/asm-s390/kvm.h
++++ b/linux-headers/asm-s390/kvm.h
+@@ -231,11 +231,13 @@ struct kvm_guest_debug_arch {
+ #define KVM_SYNC_GSCB   (1UL << 9)
+ #define KVM_SYNC_BPBC   (1UL << 10)
+ #define KVM_SYNC_ETOKEN (1UL << 11)
++#define KVM_SYNC_DIAG318 (1UL << 12)
+ 
+ #define KVM_SYNC_S390_VALID_FIELDS \
+ 	(KVM_SYNC_PREFIX | KVM_SYNC_GPRS | KVM_SYNC_ACRS | KVM_SYNC_CRS | \
+ 	 KVM_SYNC_ARCH0 | KVM_SYNC_PFAULT | KVM_SYNC_VRS | KVM_SYNC_RICCB | \
+-	 KVM_SYNC_FPRS | KVM_SYNC_GSCB | KVM_SYNC_BPBC | KVM_SYNC_ETOKEN)
++	 KVM_SYNC_FPRS | KVM_SYNC_GSCB | KVM_SYNC_BPBC | KVM_SYNC_ETOKEN) | \
++         KVM_SYNC_DIAG318)
+ 
+ /* length and alignment of the sdnx as a power of two */
+ #define SDNXC 8
+@@ -264,7 +266,8 @@ struct kvm_sync_regs {
+ 	__u8 reserved2 : 7;
+ 	__u8 padding1[51];	/* riccb needs to be 64byte aligned */
+ 	__u8 riccb[64];		/* runtime instrumentation controls block */
+-	__u8 padding2[192];	/* sdnx needs to be 256byte aligned */
++	__u64 diag318;          /* diagnose 0x318 info */
++	__u8 padding2[184];     /* sdnx needs to be 256byte aligned */
+ 	union {
+ 		__u8 sdnx[SDNXL];  /* state description annex */
+ 		struct {
+diff --git a/linux-headers/linux/kvm.h b/linux-headers/linux/kvm.h
+index 18c636070e..c38153174e 100644
+--- a/linux-headers/linux/kvm.h
++++ b/linux-headers/linux/kvm.h
+@@ -1007,6 +1007,7 @@ struct kvm_ppc_resize_hpt {
+ #define KVM_CAP_HYPERV_DIRECT_TLBFLUSH 175
+ #define KVM_CAP_S390_VCPU_RESETS 179
+ #define KVM_CAP_S390_PROTECTED 180
++#define KVM_CAP_S390_DIAG318 186
+ 
+ #ifdef KVM_CAP_IRQ_ROUTING
+ 
+diff --git a/target/s390x/cpu.h b/target/s390x/cpu.h
+index 2ec0f78b48..02e020039a 100644
+--- a/target/s390x/cpu.h
++++ b/target/s390x/cpu.h
+@@ -63,6 +63,8 @@ struct CPUS390XState {
+     uint64_t etoken;       /* etoken */
+     uint64_t etoken_extension; /* etoken extension */
+ 
++    uint64_t diag318_info;
++
+     /* Fields up to this point are not cleared by initial CPU reset */
+     struct {} start_initial_reset_fields;
+ 
+diff --git a/target/s390x/cpu_features.h b/target/s390x/cpu_features.h
+index da695a8346..f74f7fc3a1 100644
+--- a/target/s390x/cpu_features.h
++++ b/target/s390x/cpu_features.h
+@@ -23,6 +23,7 @@ typedef enum {
+     S390_FEAT_TYPE_STFL,
+     S390_FEAT_TYPE_SCLP_CONF_CHAR,
+     S390_FEAT_TYPE_SCLP_CONF_CHAR_EXT,
++    S390_FEAT_TYPE_SCLP_FAC134,
+     S390_FEAT_TYPE_SCLP_CPU,
+     S390_FEAT_TYPE_MISC,
+     S390_FEAT_TYPE_PLO,
+diff --git a/target/s390x/cpu_features_def.inc.h b/target/s390x/cpu_features_def.inc.h
+index 3548d65a69..cf7e04ee44 100644
+--- a/target/s390x/cpu_features_def.inc.h
++++ b/target/s390x/cpu_features_def.inc.h
+@@ -122,6 +122,9 @@ DEF_FEAT(SIE_CMMA, "cmma", SCLP_CONF_CHAR_EXT, 1, "SIE: Collaborative-memory-man
+ DEF_FEAT(SIE_PFMFI, "pfmfi", SCLP_CONF_CHAR_EXT, 9, "SIE: PFMF interpretation facility")
+ DEF_FEAT(SIE_IBS, "ibs", SCLP_CONF_CHAR_EXT, 10, "SIE: Interlock-and-broadcast-suppression facility")
+ 
++/* Features exposed via SCLP SCCB Facilities byte 134 (bit numbers relative to byte-134) */
++DEF_FEAT(DIAG_318, "diag318", SCLP_FAC134, 0, "Control program name and version codes")
++
+ /* Features exposed via SCLP CPU info. */
+ DEF_FEAT(SIE_F2, "sief2", SCLP_CPU, 4, "SIE: interception format 2 (Virtual SIE)")
+ DEF_FEAT(SIE_SKEY, "skey", SCLP_CPU, 5, "SIE: Storage-key facility")
+diff --git a/target/s390x/cpu_models.c b/target/s390x/cpu_models.c
+index 7e92fb2e15..522a9216a0 100644
+--- a/target/s390x/cpu_models.c
++++ b/target/s390x/cpu_models.c
+@@ -820,6 +820,7 @@ static void check_consistency(const S390CPUModel *model)
+         { S390_FEAT_PTFF_STOE, S390_FEAT_MULTIPLE_EPOCH },
+         { S390_FEAT_PTFF_STOUE, S390_FEAT_MULTIPLE_EPOCH },
+         { S390_FEAT_AP_QUEUE_INTERRUPT_CONTROL, S390_FEAT_AP },
++        { S390_FEAT_DIAG_318, S390_FEAT_EXTENDED_LENGTH_SCCB },
+     };
+     int i;
+ 
+diff --git a/target/s390x/gen-features.c b/target/s390x/gen-features.c
+index 6857f657fb..a1f0a6f3c6 100644
+--- a/target/s390x/gen-features.c
++++ b/target/s390x/gen-features.c
+@@ -523,6 +523,7 @@ static uint16_t full_GEN12_GA1[] = {
+     S390_FEAT_AP_FACILITIES_TEST,
+     S390_FEAT_AP,
+     S390_FEAT_EXTENDED_LENGTH_SCCB,
++    S390_FEAT_DIAG_318,
+ };
+ 
+ static uint16_t full_GEN12_GA2[] = {
+diff --git a/target/s390x/kvm.c b/target/s390x/kvm.c
+index 550a988086..2ac2fe0897 100644
+--- a/target/s390x/kvm.c
++++ b/target/s390x/kvm.c
+@@ -105,6 +105,7 @@
+ 
+ #define DIAG_TIMEREVENT                 0x288
+ #define DIAG_IPL                        0x308
++#define DIAG_SET_CONTROL_PROGRAM_CODES  0x318
+ #define DIAG_KVM_HYPERCALL              0x500
+ #define DIAG_KVM_BREAKPOINT             0x501
+ 
+@@ -599,6 +600,11 @@ int kvm_arch_put_registers(CPUState *cs, int level)
+         cs->kvm_run->kvm_dirty_regs |= KVM_SYNC_ETOKEN;
+     }
+ 
++    if (can_sync_regs(cs, KVM_SYNC_DIAG318)) {
++        cs->kvm_run->s.regs.diag318 = env->diag318_info;
++        cs->kvm_run->kvm_dirty_regs |= KVM_SYNC_DIAG318;
++    }
++
+     /* Finally the prefix */
+     if (can_sync_regs(cs, KVM_SYNC_PREFIX)) {
+         cs->kvm_run->s.regs.prefix = env->psa;
+@@ -738,6 +744,10 @@ int kvm_arch_get_registers(CPUState *cs)
+         }
+     }
+ 
++    if (can_sync_regs(cs, KVM_SYNC_DIAG318)) {
++        env->diag318_info = cs->kvm_run->s.regs.diag318;
++    }
++
+     return 0;
+ }
+ 
+@@ -1598,6 +1608,27 @@ static int handle_sw_breakpoint(S390CPU *cpu, struct kvm_run *run)
+     return -ENOENT;
+ }
+ 
++static void handle_diag_318(S390CPU *cpu, struct kvm_run *run)
++{
++    uint64_t reg = (run->s390_sieic.ipa & 0x00f0) >> 4;
++    uint64_t diag318_info = run->s.regs.gprs[reg];
++
++    /*
++     * DIAG 318 can only be enabled with KVM support. As such, let's
++     * ensure a guest cannot execute this instruction erroneously.
++     */
++    if (!s390_has_feat(S390_FEAT_DIAG_318)) {
++        kvm_s390_program_interrupt(cpu, PGM_SPECIFICATION);
++    }
++
++    cpu->env.diag318_info = diag318_info;
++
++    if (can_sync_regs(CPU(cpu), KVM_SYNC_DIAG318)) {
++        run->s.regs.diag318 = diag318_info;
++        run->kvm_dirty_regs |= KVM_SYNC_DIAG318;
++    }
++}
++
+ #define DIAG_KVM_CODE_MASK 0x000000000000ffff
+ 
+ static int handle_diag(S390CPU *cpu, struct kvm_run *run, uint32_t ipb)
+@@ -1617,6 +1648,9 @@ static int handle_diag(S390CPU *cpu, struct kvm_run *run, uint32_t ipb)
+     case DIAG_IPL:
+         kvm_handle_diag_308(cpu, run);
+         break;
++    case DIAG_SET_CONTROL_PROGRAM_CODES:
++        handle_diag_318(cpu, run);
++        break;
+     case DIAG_KVM_HYPERCALL:
+         r = handle_hypercall(cpu, run);
+         break;
+@@ -2446,6 +2480,11 @@ void kvm_s390_get_host_cpu_model(S390CPUModel *model, Error **errp)
+      */
+     set_bit(S390_FEAT_EXTENDED_LENGTH_SCCB, model->features);
+ 
++    /* DIAGNOSE 0x318 is not supported under protected virtualization */
++    if (!s390_is_pv() && kvm_check_extension(kvm_state, KVM_CAP_S390_DIAG318)) {
++        set_bit(S390_FEAT_DIAG_318, model->features);
++    }
++
+     /* strip of features that are not part of the maximum model */
+     bitmap_and(model->features, model->features, model->def->full_feat,
+                S390_FEAT_MAX);
+diff --git a/target/s390x/machine.c b/target/s390x/machine.c
+index 549bb6c280..5b4e82f1ab 100644
+--- a/target/s390x/machine.c
++++ b/target/s390x/machine.c
+@@ -234,6 +234,22 @@ const VMStateDescription vmstate_etoken = {
+     }
+ };
+ 
++static bool diag318_needed(void *opaque)
++{
++    return s390_has_feat(S390_FEAT_DIAG_318);
++}
++
++const VMStateDescription vmstate_diag318 = {
++    .name = "cpu/diag318",
++    .version_id = 1,
++    .minimum_version_id = 1,
++    .needed = diag318_needed,
++    .fields = (VMStateField[]) {
++        VMSTATE_UINT64(env.diag318_info, S390CPU),
++        VMSTATE_END_OF_LIST()
++    }
++};
++
+ const VMStateDescription vmstate_s390_cpu = {
+     .name = "cpu",
+     .post_load = cpu_post_load,
+@@ -270,6 +286,7 @@ const VMStateDescription vmstate_s390_cpu = {
+         &vmstate_gscb,
+         &vmstate_bpbc,
+         &vmstate_etoken,
++        &vmstate_diag318,
+         NULL
+     },
+ };
+-- 
+2.31.1
+

--- a/debian/patches/ubuntu/lp1953338-08-s390x-pv-Remove-sclp-boundary-checks.patch
+++ b/debian/patches/ubuntu/lp1953338-08-s390x-pv-Remove-sclp-boundary-checks.patch
@@ -1,0 +1,48 @@
+From a646d122860917a9050345f4d526df284d211738 Mon Sep 17 00:00:00 2001
+From: Janosch Frank <frankja@linux.ibm.com>
+Date: Thu, 22 Oct 2020 06:31:34 -0400
+Subject: [PATCH 8/9] s390x: pv: Remove sclp boundary checks
+
+The SCLP boundary cross check is done by the Ultravisor for a
+protected guest, hence we don't need to do it. As QEMU doesn't get a
+valid SCCB address in protected mode this is even problematic and can
+lead to QEMU reporting a false boundary cross error.
+
+Fixes: db13387ca0 ("s390/sclp: rework sclp boundary checks")
+Reported-by: Marc Hartmayer <mhartmay@linux.ibm.com>
+Signed-off-by: Janosch Frank <frankja@linux.ibm.com>
+Tested-by: Marc Hartmayer <mhartmay@linux.ibm.com>
+Reviewed-by: Christian Borntraeger <borntraeger@de.ibm.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Reviewed-by: Collin Walling <walling@linux.ibm.com>
+Acked-by: Halil Pasic <pasic@linux.ibm.com>
+Acked-by: David Hildenbrand <david@redhat.com>
+Message-Id: <20201022103135.126033-2-frankja@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+Origin: upstream, https://git.qemu.org/?p=qemu.git;a=commit;h=3df4843d0e612a3c838e8d94c3e9c24520f2e680
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ hw/s390x/sclp.c | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/hw/s390x/sclp.c b/hw/s390x/sclp.c
+index 44ed0a810c..63a594c00c 100644
+--- a/hw/s390x/sclp.c
++++ b/hw/s390x/sclp.c
+@@ -285,11 +285,6 @@ int sclp_service_call_protected(CPUS390XState *env, uint64_t sccb,
+         goto out_write;
+     }
+ 
+-    if (!sccb_verify_boundary(sccb, be16_to_cpu(work_sccb->h.length), code)) {
+-        work_sccb->h.response_code = cpu_to_be16(SCLP_RC_SCCB_BOUNDARY_VIOLATION);
+-        goto out_write;
+-    }
+-
+     sclp_c->execute(sclp, work_sccb, code);
+ out_write:
+     s390_cpu_pv_mem_write(env_archcpu(env), 0, work_sccb,
+-- 
+2.31.1
+

--- a/debian/patches/ubuntu/lp1953338-09-s390x-pv-Fix-diag318-PV-fencing.patch
+++ b/debian/patches/ubuntu/lp1953338-09-s390x-pv-Fix-diag318-PV-fencing.patch
@@ -1,0 +1,105 @@
+From c24785b94ef9a0631ba9b832b6e58f8f27ecaf8c Mon Sep 17 00:00:00 2001
+From: Janosch Frank <frankja@linux.ibm.com>
+Date: Thu, 22 Oct 2020 06:31:35 -0400
+Subject: [PATCH 9/9] s390x: pv: Fix diag318 PV fencing
+
+Diag318 fencing needs to be determined on the current VM PV state and
+not on the state that the VM has when we create the CPU model.
+
+Fixes: fabdada935 ("s390: guest support for diagnose 0x318")
+Reported-by: Marc Hartmayer <mhartmay@linux.ibm.com>
+Signed-off-by: Janosch Frank <frankja@linux.ibm.com>
+Tested-by: Marc Hartmayer <mhartmay@linux.ibm.com>
+Reviewed-by: Christian Borntraeger <borntraeger@de.ibm.com>
+Reviewed-by: Collin Walling <walling@linux.ibm.com>
+Acked-by: David Hildenbrand <david@redhat.com>
+Message-Id: <20201022103135.126033-3-frankja@linux.ibm.com>
+Signed-off-by: Cornelia Huck <cohuck@redhat.com>
+
+Origin: upstream, https://git.qemu.org/?p=qemu.git;a=commit;h=3ded270a2697852a71961b45291519ae044f25e3
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1953338
+Last-Update: 2022-01-24
+---
+ target/s390x/cpu_features.c | 5 +++++
+ target/s390x/cpu_features.h | 4 ++++
+ target/s390x/cpu_models.c   | 4 ++++
+ target/s390x/kvm.c          | 3 +--
+ 4 files changed, 14 insertions(+), 2 deletions(-)
+
+diff --git a/target/s390x/cpu_features.c b/target/s390x/cpu_features.c
+index 9f817e3cfa..e5cdf23260 100644
+--- a/target/s390x/cpu_features.c
++++ b/target/s390x/cpu_features.c
+@@ -14,6 +14,7 @@
+ #include "qemu/osdep.h"
+ #include "qemu/module.h"
+ #include "cpu_features.h"
++#include "hw/s390x/pv.h"
+ 
+ #define DEF_FEAT(_FEAT, _NAME, _TYPE, _BIT, _DESC) \
+     [S390_FEAT_##_FEAT] = {                        \
+@@ -105,6 +106,10 @@ void s390_fill_feat_block(const S390FeatBitmap features, S390FeatType type,
+         }
+         feat = find_next_bit(features, S390_FEAT_MAX, feat + 1);
+     }
++
++    if (type == S390_FEAT_TYPE_SCLP_FAC134 && s390_is_pv()) {
++        clear_be_bit(s390_feat_def(S390_FEAT_DIAG_318)->bit, data);
++    }
+ }
+ 
+ void s390_add_from_feat_block(S390FeatBitmap features, S390FeatType type,
+diff --git a/target/s390x/cpu_features.h b/target/s390x/cpu_features.h
+index f74f7fc3a1..d3c685a04c 100644
+--- a/target/s390x/cpu_features.h
++++ b/target/s390x/cpu_features.h
+@@ -81,6 +81,10 @@ const S390FeatGroupDef *s390_feat_group_def(S390FeatGroup group);
+ 
+ #define BE_BIT_NR(BIT) (BIT ^ (BITS_PER_LONG - 1))
+ 
++static inline void clear_be_bit(unsigned int bit_nr, uint8_t *array)
++{
++    array[bit_nr / 8] &= ~(0x80 >> (bit_nr % 8));
++}
+ static inline void set_be_bit(unsigned int bit_nr, uint8_t *array)
+ {
+     array[bit_nr / 8] |= 0x80 >> (bit_nr % 8);
+diff --git a/target/s390x/cpu_models.c b/target/s390x/cpu_models.c
+index 522a9216a0..7ce44ed942 100644
+--- a/target/s390x/cpu_models.c
++++ b/target/s390x/cpu_models.c
+@@ -29,6 +29,7 @@
+ #include "hw/pci/pci.h"
+ #endif
+ #include "qapi/qapi-commands-machine-target.h"
++#include "hw/s390x/pv.h"
+ 
+ #define CPUDEF_INIT(_type, _gen, _ec_ga, _mha_pow, _hmfai, _name, _desc) \
+     {                                                                    \
+@@ -238,6 +239,9 @@ bool s390_has_feat(S390Feat feat)
+         }
+         return 0;
+     }
++    if (feat == S390_FEAT_DIAG_318 && s390_is_pv()) {
++        return false;
++    }
+     return test_bit(feat, cpu->model->features);
+ }
+ 
+diff --git a/target/s390x/kvm.c b/target/s390x/kvm.c
+index 2ac2fe0897..9443e0e5a5 100644
+--- a/target/s390x/kvm.c
++++ b/target/s390x/kvm.c
+@@ -2480,8 +2480,7 @@ void kvm_s390_get_host_cpu_model(S390CPUModel *model, Error **errp)
+      */
+     set_bit(S390_FEAT_EXTENDED_LENGTH_SCCB, model->features);
+ 
+-    /* DIAGNOSE 0x318 is not supported under protected virtualization */
+-    if (!s390_is_pv() && kvm_check_extension(kvm_state, KVM_CAP_S390_DIAG318)) {
++    if (kvm_check_extension(kvm_state, KVM_CAP_S390_DIAG318)) {
+         set_bit(S390_FEAT_DIAG_318, model->features);
+     }
+ 
+-- 
+2.31.1
+


### PR DESCRIPTION
These patches are needed to keep this package in sync with Ubuntu's

- Import 1:4.2-3ubuntu6.20
- Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch

Another PR will follow to import 1:4.2-3ubuntu6.21 (I broke down in two to make the review easier).
