### PR TITLE
Import 1:6.2+dfsg-2ubuntu6.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,38 @@
+qemu (1:6.2+dfsg-2ubuntu6.8+exo3) UNRELEASED; urgency=medium
+
+  * Import 1:6.2+dfsg-2ubuntu6.8
+  * EXOSCALE SAUCE (no-up): Fix qemu-system-x86_64:
+    Size mismatch: 0000:00:03.0/virtio-net-pci.rom: 0x40000 != 0x80000
+  * EXOSCALE SAUCE (no-up): VNC Allow websocket connections over AF_UNIX
+    sockets
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Tue, 06 Jun 2023 16:41:24 +0000
+
+qemu (1:6.2+dfsg-2ubuntu6.8) jammy; urgency=medium
+
+  * d/p/u/lp-1999885-s390x-tod-kvm-don-t-save-restore-the-TOD-in-PV-guest.patch:
+    avoid timer issues in s390x secure execution guests (LP: #1999885)
+  * d/p/u/lp-2011832-*: fix emulation issues in mips and powerpc (LP: #2011832)
+
+ -- Christian Ehrhardt <christian.ehrhardt@canonical.com>  Thu, 23 Mar 2023 08:18:28 +0100
+
+qemu (1:6.2+dfsg-2ubuntu6.7) jammy; urgency=medium
+
+  [ Brett Milford ]
+  * d/p/u/lp1994002-migration-Read-state-once.patch: Fix for libvirt
+    error 'migration was active, but no RAM info was set' (LP: #1994002)
+
+  [ Mauricio Faria de Oliveira ]
+  * d/p/u/lp2009048-vfio_map_dma_einval_amd_iommu_1tb.patch: Add hint
+    to VFIO_MAP_DMA error on AMD IOMMU for VMs with ~1TB+ RAM (LP: #2009048)
+  * d/rules: move "Disable LTO on non-amd64" before buildflags.mk on Jammy.
+
+  [ Michal Maloszewski ]
+  * d/rules: Disable LTO on non-amd 64 architectures to prevent QEMU
+    coroutines from failing (LP: #1921664)
+
+ -- Mauricio Faria de Oliveira <mfo@canonical.com>  Mon, 06 Mar 2023 17:00:46 -0300
+
 qemu (1:6.2+dfsg-2ubuntu6.6+exo3) UNRELEASED; urgency=medium
 
   * EXOSCALE SAUCE (no-up): Fix qemu-system-x86_64:

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -50,6 +50,12 @@ CVE-2021-3750.patch
 CVE-2022-0216-1.patch
 CVE-2022-0216-2.patch
 CVE-2022-3165.patch
+ubuntu/lp1994002-migration-Read-state-once.patch
+ubuntu/lp2009048-vfio_map_dma_einval_amd_iommu_1tb.patch
+ubuntu/lp-1999885-s390x-tod-kvm-don-t-save-restore-the-TOD-in-PV-guest.patch
+ubuntu/lp-2011832-target-ppc-Fix-xs-max-min-cj-dp-to-use-VSX-registers.patch
+ubuntu/lp-2011832-target-mips-Fix-df_extract_val-and-df_extract_df-dfe.patch
+ubuntu/lp-2011832-target-mips-Fix-FTRUNC_S-and-FTRUNC_U-trans-helper.patch
 
 # Exoscale
 exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch

--- a/debian/patches/ubuntu/lp-1999885-s390x-tod-kvm-don-t-save-restore-the-TOD-in-PV-guest.patch
+++ b/debian/patches/ubuntu/lp-1999885-s390x-tod-kvm-don-t-save-restore-the-TOD-in-PV-guest.patch
@@ -1,0 +1,62 @@
+From 38621181ae3cbec62e3490fbc14f6ac01642d07a Mon Sep 17 00:00:00 2001
+From: Nico Boehr <nrb@linux.ibm.com>
+Date: Wed, 12 Oct 2022 14:32:29 +0200
+Subject: [PATCH] s390x/tod-kvm: don't save/restore the TOD in PV guests
+
+Under PV, the guest's TOD clock is under control of the ultravisor and the
+hypervisor cannot change it.
+
+With upcoming kernel changes[1], the Linux kernel will reject QEMU's
+request to adjust the guest's clock in this case, so don't attempt to set
+the clock.
+
+This avoids the following warning message on save/restore of a PV guest:
+
+warning: Unable to set KVM guest TOD clock: Operation not supported
+
+[1] https://lore.kernel.org/all/20221011160712.928239-2-nrb@linux.ibm.com/
+
+Fixes: c3347ed0d2ee ("s390x: protvirt: Support unpack facility")
+Signed-off-by: Nico Boehr <nrb@linux.ibm.com>
+Message-Id: <20221012123229.1196007-1-nrb@linux.ibm.com>
+[thuth: Add curly braces]
+Signed-off-by: Thomas Huth <thuth@redhat.com>
+
+Origin: upstream, https://gitlab.com/qemu-project/qemu/-/commit/38621181ae3
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1999885
+Last-Update: 2023-03-23
+
+---
+ hw/s390x/tod-kvm.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/hw/s390x/tod-kvm.c b/hw/s390x/tod-kvm.c
+index 9d0cbfbce2b..e2202dae2dc 100644
+--- a/hw/s390x/tod-kvm.c
++++ b/hw/s390x/tod-kvm.c
+@@ -13,6 +13,7 @@
+ #include "qemu/module.h"
+ #include "sysemu/runstate.h"
+ #include "hw/s390x/tod.h"
++#include "hw/s390x/pv.h"
+ #include "kvm/kvm_s390x.h"
+ 
+ static void kvm_s390_get_tod_raw(S390TOD *tod, Error **errp)
+@@ -84,6 +85,14 @@ static void kvm_s390_tod_vm_state_change(void *opaque, bool running,
+     S390TODState *td = opaque;
+     Error *local_err = NULL;
+ 
++    /*
++     * Under PV, the clock is under ultravisor control, hence we cannot restore
++     * it on resume.
++     */
++    if (s390_is_pv()) {
++        return;
++    }
++
+     if (running && td->stopped) {
+         /* Set the old TOD when running the VM - start the TOD clock. */
+         kvm_s390_set_tod_raw(&td->base, &local_err);
+-- 
+2.40.0
+

--- a/debian/patches/ubuntu/lp-2011832-target-mips-Fix-FTRUNC_S-and-FTRUNC_U-trans-helper.patch
+++ b/debian/patches/ubuntu/lp-2011832-target-mips-Fix-FTRUNC_S-and-FTRUNC_U-trans-helper.patch
@@ -1,0 +1,43 @@
+From 1d29f899e7f2ae9bd1bc3eb0c59e72fe932f53a6 Mon Sep 17 00:00:00 2001
+From: Ni Hui <shuizhuyuanluo@126.com>
+Date: Tue, 3 May 2022 22:42:41 +0800
+Subject: [PATCH] target/mips: Fix FTRUNC_S and FTRUNC_U trans helper
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fix the FTRUNC_S and FTRUNC_U trans helper problem.
+
+Fixes: 5c5b64000c ("target/mips: Convert MSA 2RF instruction format to decodetree")
+Signed-off-by: nihui <shuizhuyuanluo@126.com>
+Reviewed-by: Richard Henderson <richard.henderson@linaro.org>
+Reviewed-by: Philippe Mathieu-Daudé <f4bug@amsat.org>
+Message-Id: <20220503144241.289239-1-shuizhuyuanluo@126.com>
+Signed-off-by: Philippe Mathieu-Daudé <f4bug@amsat.org>
+
+Origin: upstream, https://gitlab.com/qemu-project/qemu/-/commit/1d29f899e7f
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2011832
+Last-Update: 2023-03-23
+
+---
+ target/mips/tcg/msa_translate.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/target/mips/tcg/msa_translate.c b/target/mips/tcg/msa_translate.c
+index 0b3dd0957c2..1bcdbb11215 100644
+--- a/target/mips/tcg/msa_translate.c
++++ b/target/mips/tcg/msa_translate.c
+@@ -752,8 +752,8 @@ static bool trans_msa_2rf(DisasContext *ctx, arg_msa_r *a,
+ }
+ 
+ TRANS(FCLASS,   trans_msa_2rf, gen_helper_msa_fclass_df);
+-TRANS(FTRUNC_S, trans_msa_2rf, gen_helper_msa_fclass_df);
+-TRANS(FTRUNC_U, trans_msa_2rf, gen_helper_msa_ftrunc_s_df);
++TRANS(FTRUNC_S, trans_msa_2rf, gen_helper_msa_ftrunc_s_df);
++TRANS(FTRUNC_U, trans_msa_2rf, gen_helper_msa_ftrunc_u_df);
+ TRANS(FSQRT,    trans_msa_2rf, gen_helper_msa_fsqrt_df);
+ TRANS(FRSQRT,   trans_msa_2rf, gen_helper_msa_frsqrt_df);
+ TRANS(FRCP,     trans_msa_2rf, gen_helper_msa_frcp_df);
+-- 
+2.40.0
+

--- a/debian/patches/ubuntu/lp-2011832-target-mips-Fix-df_extract_val-and-df_extract_df-dfe.patch
+++ b/debian/patches/ubuntu/lp-2011832-target-mips-Fix-df_extract_val-and-df_extract_df-dfe.patch
@@ -1,0 +1,54 @@
+From 7fc235c67f6c136ceba2305bcf2609c46a74620d Mon Sep 17 00:00:00 2001
+From: Ni Hui <shuizhuyuanluo@126.com>
+Date: Tue, 3 May 2022 21:07:06 +0800
+Subject: [PATCH] target/mips: Fix df_extract_val() and df_extract_df() dfe
+ lookup
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Actually look into dfe structure data so that df_extract_val() and
+df_extract_df() can return immediate and datafield other than BYTE.
+
+Fixes: 4701d23aef ("target/mips: Convert MSA BIT instruction format to decodetree")
+Signed-off-by: Ni Hui <shuizhuyuanluo@126.com>
+Reviewed-by: Richard Henderson <richard.henderson@linaro.org>
+Reviewed-by: Philippe Mathieu-Daudé <f4bug@amsat.org>
+Message-Id: <20220503130708.272850-2-shuizhuyuanluo@126.com>
+Signed-off-by: Philippe Mathieu-Daudé <f4bug@amsat.org>
+
+Origin: upstream, https://gitlab.com/qemu-project/qemu/-/commit/7fc235c67f6
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2011832
+Last-Update: 2023-03-23
+
+---
+ target/mips/tcg/msa_translate.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/target/mips/tcg/msa_translate.c b/target/mips/tcg/msa_translate.c
+index 76307102f29..aa45bae0aa5 100644
+--- a/target/mips/tcg/msa_translate.c
++++ b/target/mips/tcg/msa_translate.c
+@@ -68,8 +68,8 @@ struct dfe {
+ static int df_extract_val(DisasContext *ctx, int x, const struct dfe *s)
+ {
+     for (unsigned i = 0; i < 4; i++) {
+-        if (extract32(x, s->start, s->length) == s->mask) {
+-            return extract32(x, 0, s->start);
++        if (extract32(x, s[i].start, s[i].length) == s[i].mask) {
++            return extract32(x, 0, s[i].start);
+         }
+     }
+     return -1;
+@@ -82,7 +82,7 @@ static int df_extract_val(DisasContext *ctx, int x, const struct dfe *s)
+ static int df_extract_df(DisasContext *ctx, int x, const struct dfe *s)
+ {
+     for (unsigned i = 0; i < 4; i++) {
+-        if (extract32(x, s->start, s->length) == s->mask) {
++        if (extract32(x, s[i].start, s[i].length) == s[i].mask) {
+             return i;
+         }
+     }
+-- 
+2.40.0
+

--- a/debian/patches/ubuntu/lp-2011832-target-ppc-Fix-xs-max-min-cj-dp-to-use-VSX-registers.patch
+++ b/debian/patches/ubuntu/lp-2011832-target-ppc-Fix-xs-max-min-cj-dp-to-use-VSX-registers.patch
@@ -1,0 +1,94 @@
+From 201fc774e0e1cc76ec23b595968004a7b14fb6e8 Mon Sep 17 00:00:00 2001
+From: Victor Colombo <victor.colombo@eldorado.org.br>
+Date: Fri, 17 Dec 2021 17:57:18 +0100
+Subject: [PATCH] target/ppc: Fix xs{max, min}[cj]dp to use VSX registers
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+PPC instruction xsmaxcdp, xsmincdp, xsmaxjdp, and xsminjdp are using
+vector registers when they should be using VSX ones. This happens
+because the instructions are using GEN_VSX_HELPER_R3, which adds 32
+to the register numbers, effectively making them vector registers.
+
+This patch fixes it by changing these instructions to use
+GEN_VSX_HELPER_X3.
+
+Reviewed-by: Richard Henderson <richard.henderson@linaro.org>
+Signed-off-by: Victor Colombo <victor.colombo@eldorado.org.br>
+Message-Id: <20211213120958.24443-2-victor.colombo@eldorado.org.br>
+Signed-off-by: Cédric Le Goater <clg@kaod.org>
+
+Origin: upstream, https://gitlab.com/qemu-project/qemu/-/commit/201fc774e0e
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2011832
+Last-Update: 2023-03-22
+
+---
+ target/ppc/fpu_helper.c             | 4 ++--
+ target/ppc/helper.h                 | 8 ++++----
+ target/ppc/translate/vsx-impl.c.inc | 8 ++++----
+ 3 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/target/ppc/fpu_helper.c b/target/ppc/fpu_helper.c
+index 1e9a1615403..d144f21dc04 100644
+--- a/target/ppc/fpu_helper.c
++++ b/target/ppc/fpu_helper.c
+@@ -2495,7 +2495,7 @@ VSX_MAX_MIN(xvmindp, minnum, 2, float64, VsrD(i))
+ VSX_MAX_MIN(xvminsp, minnum, 4, float32, VsrW(i))
+ 
+ #define VSX_MAX_MINC(name, max)                                               \
+-void helper_##name(CPUPPCState *env, uint32_t opcode,                         \
++void helper_##name(CPUPPCState *env,                                          \
+                    ppc_vsr_t *xt, ppc_vsr_t *xa, ppc_vsr_t *xb)               \
+ {                                                                             \
+     ppc_vsr_t t = *xt;                                                        \
+@@ -2530,7 +2530,7 @@ VSX_MAX_MINC(xsmaxcdp, 1);
+ VSX_MAX_MINC(xsmincdp, 0);
+ 
+ #define VSX_MAX_MINJ(name, max)                                               \
+-void helper_##name(CPUPPCState *env, uint32_t opcode,                         \
++void helper_##name(CPUPPCState *env,                                          \
+                    ppc_vsr_t *xt, ppc_vsr_t *xa, ppc_vsr_t *xb)               \
+ {                                                                             \
+     ppc_vsr_t t = *xt;                                                        \
+diff --git a/target/ppc/helper.h b/target/ppc/helper.h
+index 72b2c70ac1f..fb946dc9742 100644
+--- a/target/ppc/helper.h
++++ b/target/ppc/helper.h
+@@ -403,10 +403,10 @@ DEF_HELPER_4(xscmpoqp, void, env, i32, vsr, vsr)
+ DEF_HELPER_4(xscmpuqp, void, env, i32, vsr, vsr)
+ DEF_HELPER_4(xsmaxdp, void, env, vsr, vsr, vsr)
+ DEF_HELPER_4(xsmindp, void, env, vsr, vsr, vsr)
+-DEF_HELPER_5(xsmaxcdp, void, env, i32, vsr, vsr, vsr)
+-DEF_HELPER_5(xsmincdp, void, env, i32, vsr, vsr, vsr)
+-DEF_HELPER_5(xsmaxjdp, void, env, i32, vsr, vsr, vsr)
+-DEF_HELPER_5(xsminjdp, void, env, i32, vsr, vsr, vsr)
++DEF_HELPER_4(xsmaxcdp, void, env, vsr, vsr, vsr)
++DEF_HELPER_4(xsmincdp, void, env, vsr, vsr, vsr)
++DEF_HELPER_4(xsmaxjdp, void, env, vsr, vsr, vsr)
++DEF_HELPER_4(xsminjdp, void, env, vsr, vsr, vsr)
+ DEF_HELPER_3(xscvdphp, void, env, vsr, vsr)
+ DEF_HELPER_4(xscvdpqp, void, env, i32, vsr, vsr)
+ DEF_HELPER_3(xscvdpsp, void, env, vsr, vsr)
+diff --git a/target/ppc/translate/vsx-impl.c.inc b/target/ppc/translate/vsx-impl.c.inc
+index c0e38060b45..02df75339ed 100644
+--- a/target/ppc/translate/vsx-impl.c.inc
++++ b/target/ppc/translate/vsx-impl.c.inc
+@@ -1098,10 +1098,10 @@ GEN_VSX_HELPER_R2_AB(xscmpoqp, 0x04, 0x04, 0, PPC2_VSX)
+ GEN_VSX_HELPER_R2_AB(xscmpuqp, 0x04, 0x14, 0, PPC2_VSX)
+ GEN_VSX_HELPER_X3(xsmaxdp, 0x00, 0x14, 0, PPC2_VSX)
+ GEN_VSX_HELPER_X3(xsmindp, 0x00, 0x15, 0, PPC2_VSX)
+-GEN_VSX_HELPER_R3(xsmaxcdp, 0x00, 0x10, 0, PPC2_ISA300)
+-GEN_VSX_HELPER_R3(xsmincdp, 0x00, 0x11, 0, PPC2_ISA300)
+-GEN_VSX_HELPER_R3(xsmaxjdp, 0x00, 0x12, 0, PPC2_ISA300)
+-GEN_VSX_HELPER_R3(xsminjdp, 0x00, 0x12, 0, PPC2_ISA300)
++GEN_VSX_HELPER_X3(xsmaxcdp, 0x00, 0x10, 0, PPC2_ISA300)
++GEN_VSX_HELPER_X3(xsmincdp, 0x00, 0x11, 0, PPC2_ISA300)
++GEN_VSX_HELPER_X3(xsmaxjdp, 0x00, 0x12, 0, PPC2_ISA300)
++GEN_VSX_HELPER_X3(xsminjdp, 0x00, 0x12, 0, PPC2_ISA300)
+ GEN_VSX_HELPER_X2(xscvdphp, 0x16, 0x15, 0x11, PPC2_ISA300)
+ GEN_VSX_HELPER_X2(xscvdpsp, 0x12, 0x10, 0, PPC2_VSX)
+ GEN_VSX_HELPER_R2(xscvdpqp, 0x04, 0x1A, 0x16, PPC2_ISA300)
+-- 
+2.40.0
+

--- a/debian/patches/ubuntu/lp1994002-migration-Read-state-once.patch
+++ b/debian/patches/ubuntu/lp1994002-migration-Read-state-once.patch
@@ -1,0 +1,63 @@
+Origin: https://gitlab.com/qemu-project/qemu/-/commit/552de79bfdd5e9e53847eb3c6d6e4cd898a4370e
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/1994002
+From 552de79bfdd5e9e53847eb3c6d6e4cd898a4370e Mon Sep 17 00:00:00 2001
+From: "Dr. David Alan Gilbert" <dgilbert@redhat.com>
+Date: Wed, 13 Apr 2022 12:33:29 +0100
+Subject: [PATCH] migration: Read state once
+
+The 'status' field for the migration is updated normally using
+an atomic operation from the migration thread.
+Most readers of it aren't that careful, and in most cases it doesn't
+matter.
+
+In query_migrate->fill_source_migration_info the 'state'
+is read twice; the first time to decide which state fields to fill in,
+and then secondly to copy the state to the status field; that can end up
+with a status that's inconsistent; e.g. setting up the fields
+for 'setup' and then having an 'active' status.  In that case
+libvirt gets upset by the lack of ram info.
+The symptom is:
+   libvirt.libvirtError: internal error: migration was active, but no RAM info was set
+
+Read the state exactly once in fill_source_migration_info.
+
+This is a possible fix for:
+https://bugzilla.redhat.com/show_bug.cgi?id=2074205
+
+Signed-off-by: Dr. David Alan Gilbert <dgilbert@redhat.com>
+Message-Id: <20220413113329.103696-1-dgilbert@redhat.com>
+Reviewed-by: Juan Quintela <quintela@redhat.com>
+Reviewed-by: Peter Xu <peterx@redhat.com>
+Signed-off-by: Dr. David Alan Gilbert <dgilbert@redhat.com>
+---
+ migration/migration.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- a/migration/migration.c
++++ b/migration/migration.c
+@@ -1073,6 +1073,7 @@ static void populate_disk_info(Migration
+ static void fill_source_migration_info(MigrationInfo *info)
+ {
+     MigrationState *s = migrate_get_current();
++    int state = qatomic_read(&s->state);
+     GSList *cur_blocker = migration_blockers;
+ 
+     info->blocked_reasons = NULL;
+@@ -1092,7 +1093,7 @@ static void fill_source_migration_info(M
+     }
+     info->has_blocked_reasons = info->blocked_reasons != NULL;
+ 
+-    switch (s->state) {
++    switch (state) {
+     case MIGRATION_STATUS_NONE:
+         /* no migration has happened ever */
+         /* do not overwrite destination migration status */
+@@ -1137,7 +1138,7 @@ static void fill_source_migration_info(M
+         info->has_status = true;
+         break;
+     }
+-    info->status = s->state;
++    info->status = state;
+ }
+ 
+ typedef enum WriteTrackingSupport {

--- a/debian/patches/ubuntu/lp2009048-vfio_map_dma_einval_amd_iommu_1tb.patch
+++ b/debian/patches/ubuntu/lp2009048-vfio_map_dma_einval_amd_iommu_1tb.patch
@@ -1,0 +1,49 @@
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2009048
+Description: Add hint to VFIO_MAP_DMA/EINVAL on AMD IOMMU for VMs with ~1TB+ RAM
+Author: Mauricio Faria de Oliveira <mfo@canonical.com>
+Forwarded: not-needed
+Last-Update: 2023-03-02
+
+Index: qemu/hw/vfio/common.c
+===================================================================
+--- qemu.orig/hw/vfio/common.c
++++ qemu/hw/vfio/common.c
+@@ -516,6 +516,38 @@ static int vfio_dma_map(VFIOContainer *c
+         return 0;
+     }
+ 
++    /*
++     * (LP: #2009048)
++     * x86_64: provide a hint if VFIO_IOMMU_DMA_MAP fails due to overlap with
++     * the reserved region (EINVAL) below 1T on AMD IOMMU (check for AMD CPU);
++     * that happens if the VM memory is ~ 1T or more (resolved with qemu 7.1).
++     *
++     * """
++     * AMD systems with an IOMMU have an additional hole close to the
++     * 1Tb, which are special GPAs that cannot be DMA mapped. Depending
++     * on kernel version, VFIO may or may not let you DMA map those ranges.
++     * Starting Linux v5.4 we validate it, and can't create guests on AMD machines
++     * with certain memory sizes. [...]
++     * """
++     *
++     * References:
++     * commit 8504f129450b ("i386/pc: relocate 4g start to 1T where applicable")
++     * commit 4ab4c33014b4 ("hw/i386: add 4g boundary start to X86MachineState")
++     */
++#ifdef TARGET_X86_64
++#define AMD_HT_START	0xfd00000000ULL
++#define PC_4GB_START	0x0100000000ULL
++    if (errno == EINVAL && iova == PC_4GB_START &&
++        size > (AMD_HT_START - PC_4GB_START) &&
++        IS_AMD_CPU(&(X86_CPU(first_cpu))->env)) {
++        error_report("VFIO_MAP_DMA failed: %s (hint: AMD IOMMU: reduce VM ram)",
++                     strerror(errno));
++        return -errno;
++    }
++#undef AMD_HT_START
++#undef PC_4GB_START
++#endif
++
+     error_report("VFIO_MAP_DMA failed: %s", strerror(errno));
+     return -errno;
+ }

--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,17 @@ SHELL = /bin/sh -e
 include /usr/share/dpkg/pkg-info.mk
 # get DEB_HOST_ARCH DEB_HOST_ARCH_OS DEB_HOST_GNU_TYPE DEB_HOST_MULTIARCH DEB_BUILD_GNU_TYPE
 include /usr/share/dpkg/architecture.mk
+
+# Disable LTO on non-amd64 builds, see:
+# https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/1921664
+# https://bugzilla.redhat.com/show_bug.cgi?id=1952483
+# [jammy backport: export before include buildflags.mk;
+#  binary-arch (configure) is not run in a child process (dh) as in
+#  kinetic, so it needs the new/non-LTO $(CFLAGS) in this process.]
+ifneq ($(DEB_HOST_ARCH),amd64)
+  export DEB_BUILD_MAINT_OPTIONS += optimize=-lto
+endif
+
 # get CFLAGS LDFLAGS etc
 include /usr/share/dpkg/buildflags.mk
 


### PR DESCRIPTION
These patches are needed to keep this package in sync with Ubuntu's

  -  Import `1:6.2+dfsg-2ubuntu6.7` and `1:6.2+dfsg-2ubuntu6.8`
  -  Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
  -  Retain debian/patches/exoscale/0001-VNC-allow-websocket-connections-over-AF_UNIX-sockets.patch

[sc-69556]