### PR TITLE
Import 1:6.2+dfsg-2ubuntu6.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+qemu (1:6.2+dfsg-2ubuntu6.10+exo3) UNRELEASED; urgency=medium
+
+  * Import 1:6.2+dfsg-2ubuntu6.10
+  * EXOSCALE SAUCE (no-up): Fix qemu-system-x86_64:
+    Size mismatch: 0000:00:03.0/virtio-net-pci.rom: 0x40000 != 0x80000
+  * EXOSCALE SAUCE (no-up): VNC Allow websocket connections over AF_UNIX
+    sockets
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Thu, 03 Aug 2023 10:51:51 +0000
+
+qemu (1:6.2+dfsg-2ubuntu6.10) jammy; urgency=medium
+
+  * d/p/u/allow-repeating-hot-unplug-requests.patch: Allow repeating
+    hot-unplug requests by making ACPI PCI able to requeue them.
+    (LP: #2018733)
+
+ -- Sergio Durigan Junior <sergio.durigan@canonical.com>  Fri, 26 May 2023 17:40:31 -0400
+
 qemu (1:6.2+dfsg-2ubuntu6.9+exo3) UNRELEASED; urgency=medium
 
   * Import 1:6.2+dfsg-2ubuntu6.9

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -57,6 +57,7 @@ ubuntu/lp-2011832-target-ppc-Fix-xs-max-min-cj-dp-to-use-VSX-registers.patch
 ubuntu/lp-2011832-target-mips-Fix-df_extract_val-and-df_extract_df-dfe.patch
 ubuntu/lp-2011832-target-mips-Fix-FTRUNC_S-and-FTRUNC_U-trans-helper.patch
 ubuntu/lp-2019766-target-arm-kvm-Retry-KVM_CREATE_VM-call-if-it-fails-.patch
+ubuntu/allow-repeating-hot-unplug-requests.patch
 
 # Exoscale
 exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch

--- a/debian/patches/ubuntu/allow-repeating-hot-unplug-requests.patch
+++ b/debian/patches/ubuntu/allow-repeating-hot-unplug-requests.patch
@@ -1,0 +1,74 @@
+From 0f689cf5ada4d5df5ab95c7f7aa9fc221afa855d Mon Sep 17 00:00:00 2001
+From: Igor Mammedov <imammedo@redhat.com>
+Date: Tue, 18 Apr 2023 11:04:49 +0200
+Subject: [PATCH] acpi: pcihp: allow repeating hot-unplug requests
+
+with Q35 using ACPI PCI hotplug by default, user's request to unplug
+device is ignored when it's issued before guest OS has been booted.
+And any additional attempt to request device hot-unplug afterwards
+results in following error:
+
+  "Device XYZ is already in the process of unplug"
+
+arguably it can be considered as a regression introduced by [2],
+before which it was possible to issue unplug request multiple
+times.
+
+Accept new uplug requests after timeout (1ms). This brings ACPI PCI
+hotplug on par with native PCIe unplug behavior [1] and allows user
+to repeat unplug requests at propper times.
+Set expire timeout to arbitrary 1msec so user won't be able to
+flood guest with SCI interrupts by calling device_del in tight loop.
+
+PS:
+ACPI spec doesn't mandate what OSPM can do with GPEx.status
+bits set before it's booted => it's impl. depended.
+Status bits may be retained (I tested with one Windows version)
+or cleared (Linux since 2.6 kernel times) during guest's ACPI
+subsystem initialization.
+Clearing status bits (though not wrong per se) hides the unplug
+event from guest, and it's upto user to repeat device_del later
+when guest is able to handle unplug requests.
+
+1) 18416c62e3 ("pcie: expire pending delete")
+2)
+Fixes: cce8944cc9ef ("qdev-monitor: Forbid repeated device_del")
+Signed-off-by: Igor Mammedov <imammedo@redhat.com>
+Acked-by: Gerd Hoffmann <kraxel@redhat.com>
+CC: mst@redhat.com
+CC: anisinha@redhat.com
+CC: jusual@redhat.com
+CC: kraxel@redhat.com
+Message-Id: <20230418090449.2155757-1-imammedo@redhat.com>
+Reviewed-by: Michael S. Tsirkin <mst@redhat.com>
+Signed-off-by: Michael S. Tsirkin <mst@redhat.com>
+Reviewed-by: Ani Sinha <anisinha@redhat.com>
+
+Origin: upstream, https://gitlab.com/qemu-project/qemu/-/commit/0f689cf5ada4
+Bug: https://gitlab.com/libvirt/libvirt/-/issues/309
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2018733
+---
+ hw/acpi/pcihp.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+Index: qemu/hw/acpi/pcihp.c
+===================================================================
+--- a/hw/acpi/pcihp.c	2023-05-26 16:00:52.488394876 -0400
++++ b/hw/acpi/pcihp.c	2023-05-26 16:00:52.488394876 -0400
+@@ -420,6 +420,16 @@
+      * acpi_pcihp_eject_slot() when the operation is completed.
+      */
+     pdev->qdev.pending_deleted_event = true;
++    /* if unplug was requested before OSPM is initialized,
++     * linux kernel will clear GPE0.sts[] bits during boot, which effectively
++     * hides unplug event. And than followup qmp_device_del() calls remain
++     * blocked by above flag permanently.
++     * Unblock qmp_device_del() by setting expire limit, so user can
++     * repeat unplug request later when OSPM has been booted.
++     */
++    pdev->qdev.pending_deleted_expires_ms =
++        qemu_clock_get_ms(QEMU_CLOCK_VIRTUAL); /* 1 msec */
++
+     s->acpi_pcihp_pci_status[bsel].down |= (1U << slot);
+     acpi_send_event(DEVICE(hotplug_dev), ACPI_PCI_HOTPLUG_STATUS);
+ }


### PR DESCRIPTION
These patches are needed to keep this package in sync with Ubuntu's

- Import 1:6.2+dfsg-2ubuntu6.9
-  Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
- Retain debian/patches/exoscale/0001-VNC-allow-websocket-connections-over-AF_UNIX-sockets.patch

[sc-72503]
[sc-74624]
