### PR TITLE
Import 1:6.2+dfsg-2ubuntu6.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+qemu (1:6.2+dfsg-2ubuntu6.12+exo3) UNRELEASED; urgency=medium
+
+  * Import 1:6.2+dfsg-2ubuntu6.12
+  * EXOSCALE SAUCE (no-up): Fix qemu-system-x86_64:
+    Size mismatch: 0000:00:03.0/virtio-net-pci.rom: 0x40000 != 0x80000
+  * EXOSCALE SAUCE (no-up): VNC Allow websocket connections over AF_UNIX
+    sockets
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Thu, 03 Aug 2023 15:55:02 +0000
+
+qemu (1:6.2+dfsg-2ubuntu6.12) jammy; urgency=medium
+
+  [ Chengen Du ]
+  * d/p/u/lp2025591-block-use-the-request-length-for-iov-alignment.patch:
+    Fix boot error on the HWE 6.2 kernel with direct IO (eg, cache=none)
+    if the logical block size is smaller than in the host (LP: #2025591)
+
+ -- Mauricio Faria de Oliveira <mfo@canonical.com>  Mon, 03 Jul 2023 18:00:25 -0300
+
 qemu (1:6.2+dfsg-2ubuntu6.11+exo3) UNRELEASED; urgency=medium
 
   * Import 1:6.2+dfsg-2ubuntu6.11

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -65,6 +65,7 @@ CVE-2022-4144-3.patch
 CVE-2022-4144-4.patch
 CVE-2022-4144-5.patch
 CVE-2023-0330.patch
+ubuntu/lp2025591-block-use-the-request-length-for-iov-alignment.patch
 
 # Exoscale
 exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch

--- a/debian/patches/ubuntu/lp2025591-block-use-the-request-length-for-iov-alignment.patch
+++ b/debian/patches/ubuntu/lp2025591-block-use-the-request-length-for-iov-alignment.patch
@@ -1,0 +1,44 @@
+From 25474d90aa50bd32e0de395a33d8de42dd6f2aef Mon Sep 17 00:00:00 2001
+From: Keith Busch <kbusch@kernel.org>
+Date: Thu, 29 Sep 2022 13:05:23 -0700
+Subject: [PATCH] block: use the request length for iov alignment
+
+An iov length needs to be aligned to the logical block size, which may
+be larger than the memory alignment.
+
+Tested-by: Jens Axboe <axboe@kernel.dk>
+Signed-off-by: Keith Busch <kbusch@kernel.org>
+Message-Id: <20220929200523.3218710-3-kbusch@meta.com>
+Reviewed-by: Kevin Wolf <kwolf@redhat.com>
+Signed-off-by: Kevin Wolf <kwolf@redhat.com>
+
+Bug-Ubuntu: https://bugs.launchpad.net/bugs/2025591
+Origin: backport, https://gitlab.com/qemu-project/qemu/-/commit/25474d90aa50bd32e0de395a33d8de42dd6f2aef
+[mfo: backport: s/file-posix.c/io.c/; remove IO_CODE() context line;]
+---
+ block/file-posix.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/block/file-posix.c b/block/file-posix.c
+index 989dfc4586c..66fdb07820c 100644
+--- a/block/io.c
++++ b/block/io.c
+@@ -3242,13 +3242,14 @@ static bool bdrv_qiov_is_aligned(BlockDriverState *bs, QEMUIOVector *qiov)
+ {
+     int i;
+     size_t alignment = bdrv_min_mem_align(bs);
++    size_t len = bs->bl.request_alignment;
+ 
+     for (i = 0; i < qiov->niov; i++) {
+         if ((uintptr_t) qiov->iov[i].iov_base % alignment) {
+             return false;
+         }
+-        if (qiov->iov[i].iov_len % alignment) {
++        if (qiov->iov[i].iov_len % len) {
+             return false;
+         }
+     }
+ 
+-- 
+GitLab
+


### PR DESCRIPTION
These patches are needed to keep this package in sync with Ubuntu's

- Import 1:6.2+dfsg-2ubuntu6.12
- Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
- Retain debian/patches/exoscale/0001-VNC-allow-websocket-connections-over-AF_UNIX-sockets.patch

[sc-74624]
