### PR TITLE
i386/acpi: restore device paths for 6.2 vms

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qemu (1:6.2+dfsg-2ubuntu6.12+exo4) UNRELEASED; urgency=medium
+
+  * EXOSCALE SAUCE (no-up) i386 acpi restore device-paths-for 6.2 vms
+    [sc-73907]
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Thu, 10 Aug 2023 10:05:29 +0000
+
 qemu (1:6.2+dfsg-2ubuntu6.12+exo3) UNRELEASED; urgency=medium
 
   * Import 1:6.2+dfsg-2ubuntu6.12

--- a/debian/patches/exoscale/0002-i386-acpi-restore-device-paths-for-6.2-vms.patch
+++ b/debian/patches/exoscale/0002-i386-acpi-restore-device-paths-for-6.2-vms.patch
@@ -1,0 +1,33 @@
+From d7932744a1eeced701d959f6b57b0299ca2f1581 Mon Sep 17 00:00:00 2001
+From: Alessandro Ratti <alessandro.ratti@exoscale.ch>
+Date: Wed, 2 Aug 2023 10:37:20 +0000
+Subject: [PATCH] i386/acpi: restore device paths for 6.2 vms
+
+After fixing the _UID value for the primary PCI root bridge in
+af1b80ae it was discovered that this change updates Windows
+configuration in an incompatible way causing network configuration
+failure unless DHCP is used.
+This change reverts the _UID update from 1 to 0 for i440fx
+VMs before version 6.2 to maintain the original behaviour when
+upgrading.
+
+[sc-73907]
+---
+ hw/i386/pc_piix.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/hw/i386/pc_piix.c b/hw/i386/pc_piix.c
+index a256905b1..26a5d649b 100644
+--- a/hw/i386/pc_piix.c
++++ b/hw/i386/pc_piix.c
+@@ -419,6 +419,7 @@ static void pc_i440fx_6_2_machine_options(MachineClass *m)
+     m->alias = "pc";
+     m->is_default = false;
+     pcmc->default_cpu_version = 1;
++    pcmc->pci_root_uid = 1;
+ }
+ 
+ DEFINE_I440FX_MACHINE(v6_2, "pc-i440fx-6.2", NULL,
+-- 
+2.25.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -70,3 +70,4 @@ ubuntu/lp2025591-block-use-the-request-length-for-iov-alignment.patch
 # Exoscale
 exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
 exoscale/0001-VNC-allow-websocket-connections-over-AF_UNIX-sockets.patch
+exoscale/0002-i386-acpi-restore-device-paths-for-6.2-vms.patch


### PR DESCRIPTION
After fixing the _UID value for the primary PCI root bridge in af1b80ae it was discovered that this change updates Windows configuration in an incompatible way causing network configuration failure unless DHCP is used.
This change reverts the _UID update from 1 to 0 for i440fx VMs before version 6.2 to maintain the original behaviour when upgrading.

[sc-73907]