### PR TITLE
Import 1:6.2+dfsg-2ubuntu6.14

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,21 @@
+qemu (1:6.2+dfsg-2ubuntu6.14+exo3) UNRELEASED; urgency=medium
+
+  * Import 1:6.2+dfsg-2ubuntu6.14
+  * EXOSCALE SAUCE (no-up): Fix qemu-system-x86_64:
+    Size mismatch: 0000:00:03.0/virtio-net-pci.rom: 0x40000 != 0x80000
+  * EXOSCALE SAUCE (no-up): VNC Allow websocket connections over AF_UNIX sockets
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Wed, 03 Jan 2024 14:03:16 +0000
+
+qemu (1:6.2+dfsg-2ubuntu6.14) jammy; urgency=medium
+
+  * d/u/lp-2033957-virtiofsd-Fix-breakage-due-to-fuse_init_in.patch:
+    Fix virtiofsd breakage due to fuse_init_in size change, which
+    happened because of the Linux kernel 5.17 headers that were
+    imported in a previous patch. (LP: #2033957)
+
+ -- Sergio Durigan Junior <sergio.durigan@canonical.com>  Tue, 05 Sep 2023 22:58:36 -0400
+
 qemu (1:6.2+dfsg-2ubuntu6.13+exo3) UNRELEASED; urgency=medium
 
   * Amend commit 1a6b0ee3b (SC: #73907)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -88,6 +88,7 @@ ubuntu/lp-1853307-s390x-pci-reflect-proper-maxstbl-for-groups-of-inter.patch
 ubuntu/lp-1853307-s390x-pci-RPCIT-second-pass-when-mappings-exhausted.patch
 ubuntu/lp-1853307-s390x-pci-shrink-DMA-aperture-to-be-bound-by-vfio-DM.patch
 ubuntu/lp-1853307-s390x-pci-reset-ISM-passthrough-devices-on-shutdown-.patch
+ubuntu/lp-2033957-virtiofsd-Fix-breakage-due-to-fuse_init_in.patch
 
 # Exoscale
 exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch

--- a/debian/patches/ubuntu/lp-2033957-virtiofsd-Fix-breakage-due-to-fuse_init_in.patch
+++ b/debian/patches/ubuntu/lp-2033957-virtiofsd-Fix-breakage-due-to-fuse_init_in.patch
@@ -1,0 +1,52 @@
+From: Vivek Goyal <vgoyal@redhat.com>
+Date: Tue, 8 Feb 2022 15:48:04 -0500
+Subject: virtiofsd: Fix breakage due to fuse_init_in size change
+
+Kernel version 5.17 has increased the size of "struct fuse_init_in" struct.
+Previously this struct was 16 bytes and now it has been extended to
+64 bytes in size.
+
+Once qemu headers are updated to latest, it will expect to receive 64 byte
+size struct (for protocol version major 7 and minor > 6). But if guest is
+booting older kernel (older than 5.17), then it still sends older
+fuse_init_in of size 16 bytes. And do_init() fails. It is expecting
+64 byte struct. And this results in mount of virtiofs failing.
+
+Fix this by parsing 16 bytes only for now. Separate patches will be
+posted which will parse rest of the bytes and enable new functionality.
+Right now we don't support any of the new functionality, so we don't
+lose anything by not parsing bytes beyond 16.
+
+Reviewed-by: Dr. David Alan Gilbert <dgilbert@redhat.com>
+Signed-off-by: Vivek Goyal <vgoyal@redhat.com>
+Message-Id: <20220208204813.682906-2-vgoyal@redhat.com>
+Signed-off-by: Dr. David Alan Gilbert <dgilbert@redhat.com>
+
+Origin: upstream, https://gitlab.com/qemu-project/qemu/-/commit/a086d54c6ffa38f7e71f182b63a25315304a3392
+Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2033957
+---
+ tools/virtiofsd/fuse_lowlevel.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tools/virtiofsd/fuse_lowlevel.c b/tools/virtiofsd/fuse_lowlevel.c
+index e4679c7..5d431a7 100644
+--- a/tools/virtiofsd/fuse_lowlevel.c
++++ b/tools/virtiofsd/fuse_lowlevel.c
+@@ -1880,6 +1880,8 @@ static void do_init(fuse_req_t req, fuse_ino_t nodeid,
+                     struct fuse_mbuf_iter *iter)
+ {
+     size_t compat_size = offsetof(struct fuse_init_in, max_readahead);
++    size_t compat2_size = offsetof(struct fuse_init_in, flags) +
++                              sizeof(uint32_t);
+     struct fuse_init_in *arg;
+     struct fuse_init_out outarg;
+     struct fuse_session *se = req->se;
+@@ -1897,7 +1899,7 @@ static void do_init(fuse_req_t req, fuse_ino_t nodeid,
+ 
+     /* ...and now consume the new fields. */
+     if (arg->major == 7 && arg->minor >= 6) {
+-        if (!fuse_mbuf_iter_advance(iter, sizeof(*arg) - compat_size)) {
++        if (!fuse_mbuf_iter_advance(iter, compat2_size - compat_size)) {
+             fuse_reply_err(req, EINVAL);
+             return;
+         }


### PR DESCRIPTION
These patches are needed to keep this package in sync with Ubuntu's

  -  Import 1:6.2+dfsg-2ubuntu6.14
  -  Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
  -  Retain debian/patches/exoscale/0001-VNC-allow-websocket-connections-over-AF_UNIX-sockets.patch

[sc-79206]