### PR TITLE
Import 1:6.2+dfsg-2ubuntu6.15

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+qemu (1:6.2+dfsg-2ubuntu6.15+exo3) UNRELEASED; urgency=medium
+
+  * Import 1:6.2+dfsg-2ubuntu6.15
+  * EXOSCALE SAUCE (no-up): Fix qemu-system-x86_64:
+    Size mismatch: 0000:00:03.0/virtio-net-pci.rom: 0x40000 != 0x80000
+  * EXOSCALE SAUCE (no-up): VNC Allow websocket connections over AF_UNIX sockets
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Wed, 03 Jan 2024 16:33:56 +0000
+
+qemu (1:6.2+dfsg-2ubuntu6.15) jammy; urgency=medium
+
+  * d/rules: remove --no-start for qemu-guest-agent (LP: #2028124)
+
+ -- Mitchell Dzurick <mitchell.dzurick@canonical.com>  Fri, 15 Sep 2023 14:39:05 -0400
+
 qemu (1:6.2+dfsg-2ubuntu6.14+exo3) UNRELEASED; urgency=medium
 
   * Import 1:6.2+dfsg-2ubuntu6.14

--- a/debian/rules
+++ b/debian/rules
@@ -426,7 +426,7 @@ binary-arch: $(addprefix install-, ${qemu-builds})
 	# install and enable qemu-kvm.service
 	dh_installsystemd -a -pqemu-system-common --no-restart-on-upgrade --name=qemu-kvm
 	dh_installinit -a -pqemu-guest-agent
-	dh_installsystemd -a -pqemu-guest-agent --no-start --no-enable
+	dh_installsystemd -a -pqemu-guest-agent --no-enable
 # default-enable /run/qemu mount only on ubuntu,
 # on debian let it be manually controlled and off by default
 	dh_installsystemd -a -pqemu-block-extra --no-restart-on-upgrade --name=run-qemu.mount \


### PR DESCRIPTION
These patches are needed to keep this package in sync with Ubuntu's

  -  Import 1:6.2+dfsg-2ubuntu6.15
  -  Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
  -  Retain debian/patches/exoscale/0001-VNC-allow-websocket-connections-over-AF_UNIX-sockets.patch

[sc-85921]