### PR TITLE
Import 1:6.2+dfsg-2ubuntu6.17

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+qemu (1:6.2+dfsg-2ubuntu6.17+exo3) UNRELEASED; urgency=medium
+
+  * Import 1:6.2+dfsg-2ubuntu6.17
+  * EXOSCALE SAUCE (no-up): Fix qemu-system-x86_64:
+    Size mismatch: 0000:00:03.0/virtio-net-pci.rom: 0x40000 != 0x80000
+  * EXOSCALE SAUCE (no-up): VNC Allow websocket connections over AF_UNIX sockets
+
+ -- Alessandro Ratti <alessandro@exoscale.com>  Mon, 05 Feb 2024 10:14:58 +0000
+
+qemu (1:6.2+dfsg-2ubuntu6.17) jammy; urgency=medium
+
+  * d/rules: modify qemu-block-extra postinst to avoid
+    restarting run-qemu.mount (LP: #2051153)
+
+ -- Christian Ehrhardt <christian.ehrhardt@canonical.com>  Mon, 29 Jan 2024 11:43:30 +0100
+
 qemu (1:6.2+dfsg-2ubuntu6.16+exo3) UNRELEASED; urgency=medium
 
   * Import 1:6.2+dfsg-2ubuntu6.16

--- a/debian/rules
+++ b/debian/rules
@@ -438,6 +438,10 @@ binary-arch: $(addprefix install-, ${qemu-builds})
 	dh_fixperms -a
 	dh_shlibdeps -a
 	dh_installdeb -a
+	# On jammy dh_installsystemd will always restart a mount unit, no matter
+	# the options we pass - hence we post-modify it in the maint scripts to
+	# match the required behavior.
+	sed -i -E 's/(\s*)(deb-systemd-invoke\s*\$$_dh_action.*run-qemu.mount.*$$)/\1# LP: 2051153 Do not restart mount units\n\1# \2/' debian/qemu-block-extra/DEBIAN/postinst
 ifeq ($(enable_linux_user),enable)
 # after shlibdeps finished, grab ${shlibs:Depends} from -user package
 # and transform it into Built-Using field for -user-static.


### PR DESCRIPTION
This patch fix an issue we discover while deploying 1:6.2+dfsg-2ubuntu6.16 within hosts running 6.2.0 (see [this comment](https://app.shortcut.com/exoscale/story/86235/update-pkg-qemu-to-1-6-2-dfsg-2ubuntu6-16#activity-87684) and the related Ubuntu bug report [LP:2051153](https://bugs.launchpad.net/ubuntu/+source/qemu/+bug/2051153)).
**Please note**: this version hasn't been yet promoted to `jammy-updates`.

-    Import 1:6.2+dfsg-2ubuntu6.17
-    Retain debian/patches/exoscale/pre-bionic-256k-ipxe-efi-roms-2.11.patch
-    Retain debian/patches/exoscale/0001-VNC-allow-websocket-connections-over-AF_UNIX-sockets.patch

[sc-86235]
